### PR TITLE
#13 Fix make compile target

### DIFF
--- a/test_app/after/src/hrl.erl
+++ b/test_app/after/src/hrl.erl
@@ -1,4 +1,4 @@
 -module(hrl).
 
--include("header.erl").
+-include("header.hrl").
 

--- a/test_app/after/src/test_sup.erl
+++ b/test_app/after/src/test_sup.erl
@@ -1,0 +1,10 @@
+-module(test_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0, init/1]).
+
+start_link() -> supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) -> {ok, {{one_for_all, 0, 1}, []}}.
+

--- a/test_app/after/src/unicode_support.erl
+++ b/test_app/after/src/unicode_support.erl
@@ -1,19 +1,11 @@
+-module(unicode_support).
 
-
--module(unicode).
-
--export([unicode_words/0]).
-
-
-
+-export([unicode_words/0, unicode_strings/0]).
 
 unicode_words() ->
     Word1 = <<"Hwæt! Wē Gār‐Dena in geār‐dagum">>,
-    Word2 = <<"þēod‐cyninga þrym gefrūnon,">>,<<Word1/binary, Word2/binary>>.
-
-
-
-
+    Word2 = <<"þēod‐cyninga þrym gefrūnon,">>,
+    <<Word1/binary, Word2/binary>>.
 
 unicode_strings() ->
     Str1 = "Hwæt! Wē Gār‐Dena in geār‐dagum",

--- a/test_app/src/hrl.erl
+++ b/test_app/src/hrl.erl
@@ -1,3 +1,3 @@
 -module (hrl).
 
--include("header.erl").
+-include("header.hrl").

--- a/test_app/src/r3fmt_test_app.app.src
+++ b/test_app/src/r3fmt_test_app.app.src
@@ -1,4 +1,4 @@
-{application, test_app, [
+{application, r3fmt_test_app, [
     {description, "A test app for the rebar3 format plugin"},
     {vsn, "0.0.1"},
     {registered, []},
@@ -6,5 +6,5 @@
     {env, []},
     {modules, []},
     {mod, {test_app, []}},
-    {licenses, ["BSD-3-Clause"]}
+    {licenses, ["MIT"]}
 ]}.

--- a/test_app/src/test_sup.erl
+++ b/test_app/src/test_sup.erl
@@ -1,0 +1,9 @@
+-module(test_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+
+start_link() ->
+  supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+  {ok, {{one_for_all, 0, 1}, []}}.

--- a/test_app/src/unicode_support.erl
+++ b/test_app/src/unicode_support.erl
@@ -1,11 +1,19 @@
--module(unicode).
 
--export([unicode_words/0]).
+
+-module(unicode_support).
+
+-export([unicode_words/0, unicode_strings/0]).
+
+
+
 
 unicode_words() ->
     Word1 = <<"Hwæt! Wē Gār‐Dena in geār‐dagum">>,
-    Word2 = <<"þēod‐cyninga þrym gefrūnon,">>,
-    <<Word1/binary, Word2/binary>>.
+    Word2 = <<"þēod‐cyninga þrym gefrūnon,">>,<<Word1/binary, Word2/binary>>.
+
+
+
+
 
 unicode_strings() ->
     Str1 = "Hwæt! Wē Gār‐Dena in geār‐dagum",


### PR DESCRIPTION
Fixes #13.

* Application name and app module name clash (both were `app_test`). Changed app name to `r3fmt_test_app`.
*  Including `header.hrl` instead of `.erl`.
* Renamed `unicode` module to `unicode_support`.