### PR TITLE
Fix 21: Complete coverage on rebar3_prettypr

### DIFF
--- a/src/rebar3_prettypr.erl
+++ b/src/rebar3_prettypr.erl
@@ -10,7 +10,7 @@
 
 -module(rebar3_prettypr).
 
--export([format/1, format/2, best/1, best/2, layout/1, layout/2]).
+-export([format/2]).
 
 -import(prettypr,
         [text/1, nest/2, above/2, beside/2, sep/1, par/1, par/2, floating/3, floating/1,
@@ -43,14 +43,6 @@ set_prec(Ctxt, Prec) ->
 
 reset_prec(Ctxt) ->
     set_prec(Ctxt, 0).    % used internally
-
-%% =====================================================================
-%% @spec format(Tree::syntaxTree()) -> string()
-%% @equiv format(Tree, [])
-
--spec format(erl_syntax:syntaxTree()) -> string().
-
-format(Node) -> format(Node, []).
 
 %% =====================================================================
 %% @spec format(Tree::syntaxTree(), Options::[term()]) -> string()
@@ -86,7 +78,6 @@ format(Node) -> format(Node, []).
 %% @see erl_syntax
 %% @see format/1
 %% @see layout/2
-%% @see best/2
 
 -spec format(erl_syntax:syntaxTree(), [term()]) -> string().
 
@@ -94,44 +85,6 @@ format(Node, Options) ->
     W = proplists:get_value(paper, Options, ?PAPER),
     L = proplists:get_value(ribbon, Options, ?RIBBON),
     prettypr:format(layout(Node, Options), W, L).
-
-%% =====================================================================
-%% @spec best(Tree::syntaxTree()) -> empty | prettypr:document()
-%% @equiv best(Tree, [])
-
--spec best(erl_syntax:syntaxTree()) -> empty | prettypr:document().
-
-best(Node) -> best(Node, []).
-
-%% =====================================================================
-%% @spec best(Tree::syntaxTree(), Options::[term()]) ->
-%%           empty | prettypr:document()
-%%
-%% @doc Creates a fixed "best" abstract layout for a syntax tree. This
-%% is similar to the `layout/2' function, except that here, the final
-%% layout has been selected with respect to the given options. The atom
-%% `empty' is returned if no such layout could be produced. For
-%% information on the options, see the `format/2' function.
-%%
-%% @see best/1
-%% @see layout/2
-%% @see format/2
-%% @see prettypr:best/3
-
--spec best(erl_syntax:syntaxTree(), [term()]) -> empty | prettypr:document().
-
-best(Node, Options) ->
-    W = proplists:get_value(paper, Options, ?PAPER),
-    L = proplists:get_value(ribbon, Options, ?RIBBON),
-    prettypr:best(layout(Node, Options), W, L).
-
-%% =====================================================================
-%% @spec layout(Tree::syntaxTree()) -> prettypr:document()
-%% @equiv layout(Tree, [])
-
--spec layout(erl_syntax:syntaxTree()) -> prettypr:document().
-
-layout(Node) -> layout(Node, []).
 
 %% =====================================================================
 %% @spec layout(Tree::syntaxTree(), Options::[term()]) -> prettypr:document()
@@ -150,7 +103,6 @@ layout(Node) -> layout(Node, []).
 %%
 %% @see prettypr
 %% @see format/2
-%% @see layout/1
 
 -spec layout(erl_syntax:syntaxTree(), [term()]) -> prettypr:document().
 

--- a/src/rebar3_prettypr.erl
+++ b/src/rebar3_prettypr.erl
@@ -28,7 +28,7 @@
 
 -define(NOUSER, undefined).
 
--type clause_t() :: case_expr | cond_expr | fun_expr | if_expr | receive_expr |
+-type clause_t() :: case_expr | fun_expr | if_expr | receive_expr |
                     try_expr | {function, prettypr:document()} | spec.
 
 -record(ctxt,
@@ -246,7 +246,6 @@ lay_no_comments(Node, Ctxt) ->
             fun_expr -> make_fun_clause(D1, D2, D3, Ctxt);
             {function, N} -> make_fun_clause(N, D1, D2, D3, Ctxt);
             if_expr -> make_if_clause(D1, D2, D3, Ctxt);
-            cond_expr -> make_if_clause(D1, D2, D3, Ctxt);
             case_expr -> make_case_clause(D1, D2, D3, Ctxt);
             receive_expr -> make_case_clause(D1, D2, D3, Ctxt);
             try_expr -> make_case_clause(D1, D2, D3, Ctxt);
@@ -273,10 +272,6 @@ lay_no_comments(Node, Ctxt) ->
           Ctxt1 = reset_prec(Ctxt),
           D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
           sep([follow(text("if"), D, Ctxt1#ctxt.sub_indent), text("end")]);
-      cond_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D = lay_clauses(erl_syntax:cond_expr_clauses(Node), cond_expr, Ctxt1),
-          sep([text("cond"), nest(Ctxt1#ctxt.sub_indent, D), text("end")]);
       fun_expr ->
           Ctxt1 = reset_prec(Ctxt),
           Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),

--- a/test_app/after/src/erl_tidy_tilde.erl
+++ b/test_app/after/src/erl_tidy_tilde.erl
@@ -1,0 +1,13 @@
+%%
+%% File:    erl_tidy_tilde.erl
+%% Author:  Mark Bucciarelli
+%% Created: 2016-06-05
+%%
+
+-module(erl_tidy_tilde).
+
+-export([start/0]).
+
+start() ->
+    io:put_chars("tilde characters ('~')in source were breaking erl_tidy\n").
+

--- a/test_app/after/src/igor_type_specs.erl
+++ b/test_app/after/src/igor_type_specs.erl
@@ -1,0 +1,76 @@
+%% Same as ./type_specs.erl, but without macros.
+-module(igor_type_specs).
+
+-include_lib("syntax_tools/include/merl.hrl").
+
+-export([f/1, b/0, c/2]).
+
+-export_type([t/0, ot/2, ff2/0]).
+
+-type aa() :: _.
+
+-type t() :: integer().
+
+-type ff(A) :: ot(A, A) | tuple() | 1..3 | map() | {}.
+
+-type ff1() :: ff(bin()) | foo:bar().
+
+-type ff2() :: {list(), [_], [integer()], nonempty_list(), [atom(), ...],
+		[ff1(), ...], [], []}.
+
+-type bin() :: <<>> | <<_:(+4)>> | <<_:_*8>> | <<_:12, _:_*16>> | <<_:16>> |
+	       <<_:16, _:_*(+0)>>.
+
+                                 % same as "<<_:16>>"
+
+-callback cb() -> t().
+
+-optional_callbacks([cb/0]).
+
+-opaque ot(A, B) :: {A, B}.
+
+-type f1() :: fun().
+
+-type f2() :: fun((...) -> t()).
+
+-type f3() :: fun(() -> t()).
+
+-type f4() :: fun((t(), t()) -> t()).
+
+-wild(attribute).
+
+-record(par, {a  :: undefined | igor_type_specs}).
+
+-record(r0, {}).
+
+-record(r, {f1  :: integer(), f2 = a  :: atom(), f3  :: fun(), f4 = 7}).
+
+-type r0() :: #r0{} | #r{f1 :: 3} | #r{f1 :: 3, f2 :: sju}.
+
+-type m1() :: #{}.
+
+-type m2() :: #{a => m1(), b => #{} | fy:m2()}.
+
+-type b1() :: B1 :: binary() | (BitString :: bitstring()).
+
+-define(PAIR(A, B), {A, B}).
+
+-spec igor_type_specs:f({r0(), r0()}) -> {t(), t()}.
+
+f({R, R}) ->
+    _ = "igor_type_specs" ++ "hej",
+    _ = <<"foo">>,
+    _ = R#r.f1,
+    _ = R#r{f1 = 17, f2 = b},
+    {1, 1}.
+
+-spec igor_type_specs:b() -> integer() | fun().
+
+b() -> case foo:bar() of #{a := 2} -> 19 end.
+
+-spec c(Atom :: atom(), Integer :: integer()) -> {atom(), integer()};
+       (X, Y) -> {atom(), float()} when X :: atom(), Y :: float();
+       (integer(), atom()) -> {integer(), atom()}.
+
+c(A, B) -> _ = integer, {A, B}.
+

--- a/test_app/after/src/m1.erl
+++ b/test_app/after/src/m1.erl
@@ -1,0 +1,16 @@
+%%
+%% File:    m1.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-24
+%%
+
+-module(m1).
+
+-export([foo/0, bar/1, baz/2]).
+
+foo() -> [m2:foo(), m2:bar()].
+
+bar(A) -> [m2:foo(A), m2:bar(A), m2:record_update(3, m2:record())].
+
+baz(A, B) -> [m2:foo(A, B), m2:bar(A, B)].
+

--- a/test_app/after/src/m2.erl
+++ b/test_app/after/src/m2.erl
@@ -1,0 +1,28 @@
+%%
+%% File:    m2.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-24
+%%
+
+-module(m2).
+
+-export([foo/0, foo/1, foo/2, bar/0, bar/1, bar/2, record_update/2, record/0]).
+
+foo() -> ok.
+
+foo(A) -> [item, A].
+
+foo(A, B) -> A + B.
+
+bar() -> true.
+
+bar(A) -> {element, A}.
+
+bar(A, B) -> A * B.
+
+-record(rec, {a, b}).
+
+record() -> #rec{a = 3, b = 0}.
+
+record_update(V, #rec{a = V0} = R) -> R#rec{a = V0 + V, b = V0}.
+

--- a/test_app/after/src/macros.erl
+++ b/test_app/after/src/macros.erl
@@ -1,3 +1,8 @@
+%%
+%% File:    syntax_tools_test.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-23
+%%
 -module(macros).
 
 -define(ADULT_AGE, 21).
@@ -16,6 +21,14 @@ is_adult_test() ->
     ?assert((is_adult(?NEW_PERSON("test1", 22)))),
     ?assertNot((is_adult(?NEW_PERSON("test2", 12)))),
     ?assert((is_adult(?SOMEONE))).
+
+-endif.
+
+-if(A_BOOLEAN_MACRO).
+
+another_hidden_function() ->
+    % string combining ?
+    is_hidden.
 
 -endif.
 

--- a/test_app/after/src/macros.erl
+++ b/test_app/after/src/macros.erl
@@ -1,8 +1,3 @@
-%%
-%% File:    syntax_tools_test.erl
-%% Author:  Björn-Egil Dahlberg
-%% Created: 2014-10-23
-%%
 -module(macros).
 
 -define(ADULT_AGE, 21).

--- a/test_app/after/src/others.erl
+++ b/test_app/after/src/others.erl
@@ -1,0 +1,55 @@
+-module(others).
+
+-compile(export_all).
+
+strange_infix_operators(A, B) -> bnot (-(A rem B)).
+
+-define(OUT_OF_CONTEXT_CLAUSE, true -> false ).
+
+-record(rec, {key, value}).
+
+named_fun_expr() ->
+    fun This(is) -> a;
+	This(recursive) -> function;
+	This(called) -> This(is)
+    end.
+
+catch_expr() ->
+    catch this:train(with, all, its, arguments,
+		     {they, might, be, too, many, to, "handle"}).
+
+comprehensions(Bin, List) ->
+    BinToBin = << <<X:1>>
+		   || <<X:8/integer>> <= Bin, X > 0,
+		      with:a_very(complex, boolean_filter, on, X) >>,
+    BinToList = [X
+		 || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X)],
+    ListToBin = << <<X:1>>
+		    || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
+    ListToList = [X
+		  || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X)],
+    {BinToBin, BinToList, ListToBin, ListToList}.
+
+parentheses() ->
+    {"does                            ", this,
+     [[code, <<"        look         ">>, like], "lisp", to,
+      [{[<<"(      you or me or them?)">>]}]]}.
+
+receive_expr() -> receive with -> {no, timeout} end.
+
+record_index_expr(List) -> lists:keyfind(a, #rec.key, List).
+
+try_expr_after() ->
+    try to:open({the, door}) of
+      my -> room or your;
+      room -> {my, friend}
+    catch
+      {you_cant, Open} when Open -> it:was(Open)
+    after
+      close:the(door, anyway)
+    end,
+    try with:no(catching) after
+      do:something({to, "clean up", <<"the">>, [filthy, filthy, mess], you, created,
+		    "if you can"})
+    end.
+

--- a/test_app/after/src/others.erl
+++ b/test_app/after/src/others.erl
@@ -53,3 +53,11 @@ try_expr_after() ->
 		    "if you can"})
     end.
 
+bit_types(X) ->
+    <<X:4/little-signed-integer-unit:8,
+      (something:on(X)):32/big-unsigned-integer-unit:32>>.
+
+numbers() ->
+    {1.0, 1.0, 1.00099999999999988987, 4294967295, 341, 4681, -1.0e+1, 5.0e-2,
+     1.2312231234e+16, 1.19999999999999995559, 1.19999999999999995559e-1}.
+

--- a/test_app/after/src/specs_and_funs.erl
+++ b/test_app/after/src/specs_and_funs.erl
@@ -1,0 +1,16 @@
+-module(specs_and_funs).
+
+-export([my_apply/3, two/1]).
+
+%% OTP-15519, ERL-815
+
+-spec my_apply(Fun, Arg, fun((A) -> A)) -> Result when Fun ::
+							   fun((Arg) -> Result),
+						       Arg :: any(), Result :: any().
+
+my_apply(Fun, Arg, _) -> Fun(Arg).
+
+-spec two(fun((A) -> A)) -> fun((B) -> B).
+
+two(F) -> F(fun (X) -> X end).
+

--- a/test_app/after/src/syntax_tools_SUITE_test_module.erl
+++ b/test_app/after/src/syntax_tools_SUITE_test_module.erl
@@ -1,0 +1,455 @@
+-module(syntax_tools_SUITE_test_module).
+
+-export([foo1/1, foo2/3, start_child/2]).
+
+-export([len/1, equal/2, concat/2, chr/2, rchr/2, str/2, rstr/2, span/2,
+	 cspan/2, substr/2, substr/3, tokens/2, chars/2, chars/3]).
+
+-export([copies/2, words/1, words/2, strip/1, strip/2, strip/3, sub_word/2,
+	 sub_word/3, left/2, left/3, right/2, right/3, sub_string/2, sub_string/3,
+	 centre/2, centre/3, join/2]).
+
+-export([to_upper/1, to_lower/1]).
+
+-import(lists, [reverse/1, member/2]).
+
+%% @type some_type() = map()
+%% @type some_other_type() = {a, #{ list() => term()}}
+
+-type some_type() :: map().
+
+-type some_other_type() :: {a, #{list() => term()}}.
+
+-spec foo1(Map :: #{a => integer(), b => term()}) -> term().
+
+%% @doc Gets value from map.
+
+foo1(#{a := 1, b := V}) -> V.
+
+%% @spec foo2(some_type(), Type2 :: some_other_type(), map()) -> Value
+%% @doc Gets value from map.
+
+-spec foo2(Type1 :: some_type(), Type2 :: some_other_type(),
+	   Map :: #{get => value, value => binary()}) -> binary().
+
+foo2(Type1, {a, #{"a" := _}}, #{get := value, value := B}) when is_map(Type1) ->
+    B.
+
+%% from supervisor 18.0
+
+-type child() :: undefined | pid().
+
+-type child_id() :: term().
+
+-type mfargs() :: {M :: module(), F :: atom(), A :: [term()] | undefined}.
+
+-type modules() :: [module()] | dynamic.
+
+-type restart() :: permanent | transient | temporary.
+
+-type shutdown() :: brutal_kill | timeout().
+
+-type worker() :: worker | supervisor.
+
+-type sup_ref() :: (Name :: atom()) | {Name :: atom(), Node :: node()} |
+		   {global, Name :: atom()} | {via, Module :: module(), Name :: any()} | pid().
+
+-type child_spec() :: #{name => child_id(), start => mfargs(),
+			restart => restart(), shutdown => shutdown(), type => worker(),
+			modules => modules()} |
+		      {Id :: child_id(), StartFunc :: mfargs(), Restart :: restart(),
+		       Shutdown :: shutdown(), Type :: worker(),
+		       Modules :: modules()}.     % mandatory
+					           % mandatory
+
+                                                % optional
+ % optional
+
+                                                % optional
+   % optional
+
+-type startchild_err() :: already_present |
+			  {already_started, Child :: child()} | term().
+
+-type startchild_ret() :: {ok, Child :: child()} |
+			  {ok, Child :: child(), Info :: term()} | {error, startchild_err()}.
+
+-spec start_child(SupRef, ChildSpec) -> startchild_ret() when SupRef ::
+								  sup_ref(),
+							      ChildSpec :: child_spec() |
+									   (List :: [term()]).
+
+start_child(Supervisor, ChildSpec) -> {Supervisor, ChildSpec}.
+
+%% From string.erl
+%% Robert's bit
+
+%% len(String)
+%%  Return the length of a string.
+
+-spec len(String) -> Length when String :: string(),
+				 Length :: non_neg_integer().
+
+len(S) -> length(S).
+
+%% equal(String1, String2)
+%%  Test if 2 strings are equal.
+
+-spec equal(String1, String2) -> boolean() when String1 :: string(),
+						String2 :: string().
+
+equal(S, S) -> true;
+equal(_, _) -> false.
+
+%% concat(String1, String2)
+%%  Concatenate 2 strings.
+
+-spec concat(String1, String2) -> String3 when String1 :: string(),
+					       String2 :: string(), String3 :: string().
+
+concat(S1, S2) -> S1 ++ S2.
+
+%% chr(String, Char)
+%% rchr(String, Char)
+%%  Return the first/last index of the character in a string.
+
+-spec chr(String, Character) -> Index when String :: string(),
+					   Character :: char(), Index :: non_neg_integer().
+
+chr(S, C) when is_integer(C) -> chr(S, C, 1).
+
+chr([C | _Cs], C, I) -> I;
+chr([_ | Cs], C, I) -> chr(Cs, C, I + 1);
+chr([], _C, _I) -> 0.
+
+-spec rchr(String, Character) -> Index when String :: string(),
+					    Character :: char(), Index :: non_neg_integer().
+
+rchr(S, C) when is_integer(C) -> rchr(S, C, 1, 0).
+
+rchr([C | Cs], C, I,
+     _L) ->                       %Found one, now find next!
+    rchr(Cs, C, I + 1, I);
+rchr([_ | Cs], C, I, L) -> rchr(Cs, C, I + 1, L);
+rchr([], _C, _I, L) -> L.
+
+%% str(String, SubString)
+%% rstr(String, SubString)
+%% index(String, SubString)
+%%  Return the first/last index of the sub-string in a string.
+%%  index/2 is kept for backwards compatibility.
+
+-spec str(String, SubString) -> Index when String :: string(),
+					   SubString :: string(), Index :: non_neg_integer().
+
+str(S, Sub) when is_list(Sub) -> str(S, Sub, 1).
+
+str([C | S], [C | Sub], I) ->
+    case prefix(Sub, S) of
+      true -> I;
+      false -> str(S, [C | Sub], I + 1)
+    end;
+str([_ | S], Sub, I) -> str(S, Sub, I + 1);
+str([], _Sub, _I) -> 0.
+
+-spec rstr(String, SubString) -> Index when String :: string(),
+					    SubString :: string(), Index :: non_neg_integer().
+
+rstr(S, Sub) when is_list(Sub) -> rstr(S, Sub, 1, 0).
+
+rstr([C | S], [C | Sub], I, L) ->
+    case prefix(Sub, S) of
+      true -> rstr(S, [C | Sub], I + 1, I);
+      false -> rstr(S, [C | Sub], I + 1, L)
+    end;
+rstr([_ | S], Sub, I, L) -> rstr(S, Sub, I + 1, L);
+rstr([], _Sub, _I, L) -> L.
+
+prefix([C | Pre], [C | String]) -> prefix(Pre, String);
+prefix([], String) when is_list(String) -> true;
+prefix(Pre, String) when is_list(Pre), is_list(String) -> false.
+
+%% span(String, Chars) -> Length.
+%% cspan(String, Chars) -> Length.
+
+-spec span(String, Chars) -> Length when String :: string(), Chars :: string(),
+					 Length :: non_neg_integer().
+
+span(S, Cs) when is_list(Cs) -> span(S, Cs, 0).
+
+span([C | S], Cs, I) ->
+    case member(C, Cs) of
+      true -> span(S, Cs, I + 1);
+      false -> I
+    end;
+span([], _Cs, I) -> I.
+
+-spec cspan(String, Chars) -> Length when String :: string(), Chars :: string(),
+					  Length :: non_neg_integer().
+
+cspan(S, Cs) when is_list(Cs) -> cspan(S, Cs, 0).
+
+cspan([C | S], Cs, I) ->
+    case member(C, Cs) of
+      true -> I;
+      false -> cspan(S, Cs, I + 1)
+    end;
+cspan([], _Cs, I) -> I.
+
+%% substr(String, Start)
+%% substr(String, Start, Length)
+%%  Extract a sub-string from String.
+
+-spec substr(String, Start) -> SubString when String :: string(),
+					      SubString :: string(), Start :: pos_integer().
+
+substr(String, 1) when is_list(String) -> String;
+substr(String, S) when is_integer(S), S > 1 -> substr2(String, S).
+
+-spec substr(String, Start, Length) -> SubString when String :: string(),
+						      SubString :: string(), Start :: pos_integer(),
+						      Length :: non_neg_integer().
+
+substr(String, S, L) when is_integer(S), S >= 1, is_integer(L), L >= 0 ->
+    substr1(substr2(String, S), L).
+
+substr1([C | String], L) when L > 0 -> [C | substr1(String, L - 1)];
+substr1(String, _L) when is_list(String) -> [].      %Be nice!
+
+substr2(String, 1) when is_list(String) -> String;
+substr2([_ | String], S) -> substr2(String, S - 1).
+
+%% tokens(String, Seperators).
+%%  Return a list of tokens seperated by characters in Seperators.
+
+-spec tokens(String, SeparatorList) -> Tokens when String :: string(),
+						   SeparatorList :: string(),
+						   Tokens :: [Token :: nonempty_string()].
+
+tokens(S, Seps) -> tokens1(S, Seps, []).
+
+tokens1([C | S], Seps, Toks) ->
+    case member(C, Seps) of
+      true -> tokens1(S, Seps, Toks);
+      false -> tokens2(S, Seps, Toks, [C])
+    end;
+tokens1([], _Seps, Toks) -> reverse(Toks).
+
+tokens2([C | S], Seps, Toks, Cs) ->
+    case member(C, Seps) of
+      true -> tokens1(S, Seps, [reverse(Cs) | Toks]);
+      false -> tokens2(S, Seps, Toks, [C | Cs])
+    end;
+tokens2([], _Seps, Toks, Cs) -> reverse([reverse(Cs) | Toks]).
+
+-spec chars(Character, Number) -> String when Character :: char(),
+					      Number :: non_neg_integer(), String :: string().
+
+chars(C, N) -> chars(C, N, []).
+
+-spec chars(Character, Number, Tail) -> String when Character :: char(),
+						    Number :: non_neg_integer(), Tail :: string(),
+						    String :: string().
+
+chars(C, N, Tail) when N > 0 -> chars(C, N - 1, [C | Tail]);
+chars(C, 0, Tail) when is_integer(C) -> Tail.
+
+%% Torbjörn's bit.
+
+%%% COPIES %%%
+
+-spec copies(String, Number) -> Copies when String :: string(),
+					    Copies :: string(), Number :: non_neg_integer().
+
+copies(CharList, Num) when is_list(CharList), is_integer(Num), Num >= 0 ->
+    copies(CharList, Num, []).
+
+copies(_CharList, 0, R) -> R;
+copies(CharList, Num, R) -> copies(CharList, Num - 1, CharList ++ R).
+
+%%% WORDS %%%
+
+-spec words(String) -> Count when String :: string(), Count :: pos_integer().
+
+words(String) -> words(String, $\s).
+
+-spec words(String, Character) -> Count when String :: string(),
+					     Character :: char(), Count :: pos_integer().
+
+words(String, Char) when is_integer(Char) ->
+    w_count(strip(String, both, Char), Char, 0).
+
+w_count([], _, Num) -> Num + 1;
+w_count([H | T], H, Num) -> w_count(strip(T, left, H), H, Num + 1);
+w_count([_H | T], Char, Num) -> w_count(T, Char, Num).
+
+%%% SUB_WORDS %%%
+
+-spec sub_word(String, Number) -> Word when String :: string(),
+					    Word :: string(), Number :: integer().
+
+sub_word(String, Index) -> sub_word(String, Index, $\s).
+
+-spec sub_word(String, Number, Character) -> Word when String :: string(),
+						       Word :: string(), Number :: integer(),
+						       Character :: char().
+
+sub_word(String, Index, Char) when is_integer(Index), is_integer(Char) ->
+    case words(String, Char) of
+      Num when Num < Index -> [];
+      _Num -> s_word(strip(String, left, Char), Index, Char, 1, [])
+    end.
+
+s_word([], _, _, _, Res) -> reverse(Res);
+s_word([Char | _], Index, Char, Index, Res) -> reverse(Res);
+s_word([H | T], Index, Char, Index, Res) ->
+    s_word(T, Index, Char, Index, [H | Res]);
+s_word([Char | T], Stop, Char, Index, Res) when Index < Stop ->
+    s_word(strip(T, left, Char), Stop, Char, Index + 1, Res);
+s_word([_ | T], Stop, Char, Index, Res) when Index < Stop ->
+    s_word(T, Stop, Char, Index, Res).
+
+%%% STRIP %%%
+
+-spec strip(string()) -> string().
+
+strip(String) -> strip(String, both).
+
+-spec strip(String, Direction) -> Stripped when String :: string(),
+						Stripped :: string(),
+						Direction :: left | right | both.
+
+strip(String, left) -> strip_left(String, $\s);
+strip(String, right) -> strip_right(String, $\s);
+strip(String, both) -> strip_right(strip_left(String, $\s), $\s).
+
+-spec strip(String, Direction, Character) -> Stripped when String :: string(),
+							   Stripped :: string(),
+							   Direction :: left | right | both,
+							   Character :: char().
+
+strip(String, right, Char) -> strip_right(String, Char);
+strip(String, left, Char) -> strip_left(String, Char);
+strip(String, both, Char) -> strip_right(strip_left(String, Char), Char).
+
+strip_left([Sc | S], Sc) -> strip_left(S, Sc);
+strip_left([_ | _] = S, Sc) when is_integer(Sc) -> S;
+strip_left([], Sc) when is_integer(Sc) -> [].
+
+strip_right([Sc | S], Sc) ->
+    case strip_right(S, Sc) of
+      [] -> [];
+      T -> [Sc | T]
+    end;
+strip_right([C | S], Sc) -> [C | strip_right(S, Sc)];
+strip_right([], Sc) when is_integer(Sc) -> [].
+
+%%% LEFT %%%
+
+-spec left(String, Number) -> Left when String :: string(), Left :: string(),
+					Number :: non_neg_integer().
+
+left(String, Len) when is_integer(Len) -> left(String, Len, $\s).
+
+-spec left(String, Number, Character) -> Left when String :: string(),
+						   Left :: string(), Number :: non_neg_integer(),
+						   Character :: char().
+
+left(String, Len, Char) when is_integer(Char) ->
+    Slen = length(String),
+    if Slen > Len -> substr(String, 1, Len);
+       Slen < Len -> l_pad(String, Len - Slen, Char);
+       Slen =:= Len -> String
+    end.
+
+l_pad(String, Num, Char) -> String ++ chars(Char, Num).
+
+%%% RIGHT %%%
+
+-spec right(String, Number) -> Right when String :: string(), Right :: string(),
+					  Number :: non_neg_integer().
+
+right(String, Len) when is_integer(Len) -> right(String, Len, $\s).
+
+-spec right(String, Number, Character) -> Right when String :: string(),
+						     Right :: string(), Number :: non_neg_integer(),
+						     Character :: char().
+
+right(String, Len, Char) when is_integer(Char) ->
+    Slen = length(String),
+    if Slen > Len -> substr(String, Slen - Len + 1);
+       Slen < Len -> r_pad(String, Len - Slen, Char);
+       Slen =:= Len -> String
+    end.
+
+r_pad(String, Num, Char) -> chars(Char, Num, String).
+
+%%% CENTRE %%%
+
+-spec centre(String, Number) -> Centered when String :: string(),
+					      Centered :: string(), Number :: non_neg_integer().
+
+centre(String, Len) when is_integer(Len) -> centre(String, Len, $\s).
+
+-spec centre(String, Number, Character) -> Centered when String :: string(),
+							 Centered :: string(),
+							 Number :: non_neg_integer(),
+							 Character :: char().
+
+centre(String, 0, Char) when is_list(String), is_integer(Char) ->
+    [];                       % Strange cases to centre string
+centre(String, Len, Char) when is_integer(Char) ->
+    Slen = length(String),
+    if Slen > Len -> substr(String, (Slen - Len) div 2 + 1, Len);
+       Slen < Len ->
+	   N = (Len - Slen) div 2, r_pad(l_pad(String, Len - (Slen + N), Char), N, Char);
+       Slen =:= Len -> String
+    end.
+
+%%% SUB_STRING %%%
+
+-spec sub_string(String, Start) -> SubString when String :: string(),
+						  SubString :: string(), Start :: pos_integer().
+
+sub_string(String, Start) -> substr(String, Start).
+
+-spec sub_string(String, Start, Stop) -> SubString when String :: string(),
+							SubString :: string(),
+							Start :: pos_integer(),
+							Stop :: pos_integer().
+
+sub_string(String, Start, Stop) -> substr(String, Start, Stop - Start + 1).
+
+%% ISO/IEC 8859-1 (latin1) letters are converted, others are ignored
+%%
+
+to_lower_char(C) when is_integer(C), $A =< C, C =< $Z -> C + 32;
+to_lower_char(C) when is_integer(C), 192 =< C, C =< 214 -> C + 32;
+to_lower_char(C) when is_integer(C), 216 =< C, C =< 222 -> C + 32;
+to_lower_char(C) -> C.
+
+to_upper_char(C) when is_integer(C), $a =< C, C =< $z -> C - 32;
+to_upper_char(C) when is_integer(C), 224 =< C, C =< 246 -> C - 32;
+to_upper_char(C) when is_integer(C), 248 =< C, C =< 254 -> C - 32;
+to_upper_char(C) -> C.
+
+-spec to_lower(String) -> Result when String :: io_lib:latin1_string(),
+				      Result :: io_lib:latin1_string();
+	      (Char) -> CharResult when Char :: char(), CharResult :: char().
+
+to_lower(S) when is_list(S) -> [to_lower_char(C) || C <- S];
+to_lower(C) when is_integer(C) -> to_lower_char(C).
+
+-spec to_upper(String) -> Result when String :: io_lib:latin1_string(),
+				      Result :: io_lib:latin1_string();
+	      (Char) -> CharResult when Char :: char(), CharResult :: char().
+
+to_upper(S) when is_list(S) -> [to_upper_char(C) || C <- S];
+to_upper(C) when is_integer(C) -> to_upper_char(C).
+
+-spec join(StringList, Separator) -> String when StringList :: [string()],
+						 Separator :: string(), String :: string().
+
+join([], Sep) when is_list(Sep) -> [];
+join([H | T], Sep) -> H ++ lists:append([Sep ++ X || X <- T]).
+

--- a/test_app/after/src/syntax_tools_test.erl
+++ b/test_app/after/src/syntax_tools_test.erl
@@ -1,0 +1,113 @@
+%%
+%% File:    syntax_tools_test.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-23
+%%
+
+-module(syntax_tools_test).
+
+-export([foo1/0, foo2/2, foo3/0, foo4/3, foo5/1]).
+
+-include_lib("kernel/include/file.hrl").
+
+-record(state, {a, b, c, d}).
+
+-attribute([{foo, 0}]).
+
+%% @todo handle this https://github.com/AdRoll/rebar3_format/issues/22
+% -define(attrib, some_attrib).
+% -?attrib([foo2/2]).
+
+-define(macro_simple1, ok).
+
+-define(MACRO_SIMPLE2, other).
+
+-define(macro_simple3, ?MODULE).
+
+-define(macro_simple4, [?macro_simple3, ?MODULE, ?MACRO_SIMPLE2]).
+
+-define(macro_simple5, process_info).
+
+-define(macro_string, "hello world").
+
+-define(macro_argument1(X), X + 3).
+
+-define(macro_argument2(X, Y), X + 3 * Y).
+
+-define(macro_block(X), begin X end).
+
+-define(macro_if(X1, X2),
+	if X1 -> X2;
+	   true -> none
+	end).
+
+-ifdef(macro_def1).
+
+-define(macro_cond1, yep).
+
+-else.
+
+-define(macro_cond1, nope).
+
+-endif.
+
+-ifndef(macro_def2).
+
+-define(macro_cond2, nope).
+
+-else.
+
+-define(macro_cond2, yep).
+
+-endif.
+
+-undef(macro_def1).
+
+-undef(macro_def2).
+
+%% basic test
+foo1() -> ok.
+
+%% macro test
+foo2(A, B) ->
+    %% @todo handle string combining
+    %%       https://github.com/AdRoll/rebar3_format/issues/22
+    %%    [?macro_string ?macro_string,
+    [?macro_string, "hello world more hello",
+     [?macro_simple1, ?MACRO_SIMPLE2, ?macro_simple3, ?macro_simple4, ?macro_simple5,
+      ?macro_string, ?macro_cond1, ?macro_cond2, ?macro_block(A), ?macro_if(A, B),
+      ?macro_argument1(A), ?macro_argument1(begin A end), ?macro_block(<<"hello">>),
+      ?macro_block("hello"), ?macro_block([$h, $e, $l, $l, $0]),
+      ?macro_argument1((id(<<"hello">>))),
+      ?macro_argument1(if A -> B;
+			  true -> 3.14
+		       end),
+      ?macro_argument1(case A of
+			 ok -> B;
+			 C -> C
+		       end),
+      ?macro_argument1(receive M -> M after 100 -> 3 end),
+      ?macro_argument1(try foo5(A) catch C:(?macro_simple5) -> {C, B} end),
+      ?macro_argument2(A, B)],
+     A, B, ok].
+
+id(I) -> I.
+
+%% basic terms
+
+foo3() ->
+    [atom, 'some other atom', {tuple, 1, 2, 3}, 1, 2, 3, 3333, 3, 3333, 2, 1,
+     [$a, $b, $c], "hello world", <<"hello world">>, <<1, 2, 3, 4, 5:6>>, 3.1415,
+     1.02999999999999996700e+33].
+
+%% application and records
+
+foo4(A, B, #state{c = C} = S) ->
+    Ls = foo3(),
+    S1 = #state{a = 1, b = 2},
+    [foo2(A, Ls), B, C, B(3, C), erlang:process_info(self()),
+     erlang:(?macro_simple5)(self()), A:(?MACRO_SIMPLE2)(), A:(?macro_simple1)(),
+     A:process_info(self()), A:B(3), S#state{a = 2, b = B, d = S1}].
+
+foo5(A) -> try foo2(A, A) of R -> R catch error:(?macro_simple5) -> nope end.
+

--- a/test_app/after/src/type_specs.erl
+++ b/test_app/after/src/type_specs.erl
@@ -1,0 +1,87 @@
+-module(type_specs).
+
+-include_lib("syntax_tools/include/merl.hrl").
+
+-export([f/1, b/0, c/2]).
+
+-export_type([t/0, ot/2, ff2/0]).
+
+-type aa() :: _.
+
+-type t() :: integer().
+
+-type ff(A) :: ot(A, A) | tuple() | 1..3 | map() | {}.
+
+-type ff1() :: ff(bin()) | foo:bar().
+
+-type ff2() :: {list(), [_], [integer()], nonempty_list(), [atom(), ...],
+		[ff1(), ...], [], []}.
+
+-type bin() :: <<>> | <<_:(+4)>> | <<_:_*8>> | <<_:12, _:_*16>> | <<_:16>> |
+	       <<_:16, _:_*(+0)>>.
+
+                                 % same as "<<_:16>>"
+
+-callback cb() -> t().
+
+-optional_callbacks([cb/0]).
+
+-opaque ot(A, B) :: {A, B}.
+
+-type f1() :: fun().
+
+-type f2() :: fun((...) -> t()).
+
+-type f3() :: fun(() -> t()).
+
+-type f4() :: fun((t(), t()) -> t()).
+
+-wild(attribute).
+
+-record(par, {a  :: undefined | (?MODULE)}).
+
+-record(r0, {}).
+
+-record(r, {f1  :: integer(), f2 = a  :: atom(), f3  :: fun(), f4 = 7}).
+
+-type r0() :: #r0{} | #r{f1 :: 3} | #r{f1 :: 3, f2 :: sju}.
+
+-type m1() :: #{} | map().
+
+-type m2() :: #{a := m1(), b => #{} | fy:m2()}.
+
+%-type m3() :: #{...}.
+%-type m4() :: #{_ => _, ...}.
+%-type m5() :: #{any() => any(), ...}.
+-type m3() :: #{any() => any()}.
+
+-type m4() :: #{_ => _, any() => any()}.
+
+-type m5() :: #{any() => any(), any() => any()}.
+
+-type b1() :: B1 :: binary() | (BitString :: bitstring()).
+
+-define(PAIR(A, B), {A, B}).
+
+-spec (?MODULE):f('?<macro> ('(PAIR, r0(), r0())) -> '?<macro> ('(PAIR, t(),
+								  t()).
+
+f({R, R}) ->
+    _ = (?MODULE_STRING) ++ "hej",
+    _ = <<"foo">>,
+    _ = R#r.f1,
+    _ = R#r{f1 = 17, f2 = b},
+    {1, 1}.
+
+-spec (?MODULE):b() -> integer() | fun().
+
+b() -> case foo:bar() of #{a := 2} -> 19 end.
+
+-define(I, integer).
+
+-spec c(Atom :: atom(), Integer :: '?<macro> ('(I)) -> {atom(), integer()};
+       (X, Y) -> {atom(), float()} when X :: atom(), Y :: float();
+       (integer(), atom()) -> {integer(), atom()}.
+
+c(A, B) -> _ = (?I), {A, B}.
+

--- a/test_app/rebar.config
+++ b/test_app/rebar.config
@@ -16,6 +16,6 @@
 
 {deps, []}.
 
-{plugins, [{rebar3_format, {git, "git@github.com:AdRoll/rebar3_format.git", {branch, "master"}}}]}.
+{plugins, [rebar3_format]}.
 
 {format, [{files, ["src/*.erl", "include/*.hrl"]}, {dummy, option}]}.

--- a/test_app/src/erl_tidy_tilde.erl
+++ b/test_app/src/erl_tidy_tilde.erl
@@ -1,0 +1,13 @@
+%%
+%% File:    erl_tidy_tilde.erl
+%% Author:  Mark Bucciarelli
+%% Created: 2016-06-05
+%%
+
+-module(erl_tidy_tilde).
+
+-export([start/0]).
+
+start() ->
+    io:put_chars("tilde characters ('~')in source were "
+                 "breaking erl_tidy\n").

--- a/test_app/src/igor_type_specs.erl
+++ b/test_app/src/igor_type_specs.erl
@@ -1,0 +1,80 @@
+%% Same as ./type_specs.erl, but without macros.
+-module(igor_type_specs).
+
+-include_lib("syntax_tools/include/merl.hrl").
+
+-export([f/1, b/0, c/2]).
+
+-export_type([t/0, ot/2, ff2/0]).
+
+-type aa() :: _.
+
+-type t() :: integer().
+
+-type ff(A) :: ot(A, A) | tuple() | 1..3 | map() | {}.
+-type ff1() :: ff(bin()) | foo:bar().
+-type ff2() :: {list(), [_], list(integer()),
+                nonempty_list(), nonempty_list(atom()), [ff1(), ...],
+                nil(), []}.
+-type bin() :: <<>>
+             | <<_:(+4)>>
+             | <<_:_*8>>
+             | <<_:12, _:_*16>>
+             | <<_:16, _:_*(0)>> % same as "<<_:16>>"
+             | <<_:16, _:_*(+0)>>.
+
+-callback cb() -> t().
+
+-optional_callbacks([cb/0]).
+
+-opaque ot(A, B) :: {A, B}.
+
+-type f1() :: fun().
+-type f2() :: fun((...) -> t()).
+-type f3() :: fun(() -> t()).
+-type f4() :: fun((t(), t()) -> t()).
+
+-wild(attribute).
+
+-record(par, {a :: undefined | igor_type_specs}).
+
+-record(r0, {}).
+
+-record(r,
+        {f1 :: integer(),
+         f2 = a :: atom(),
+         f3 :: fun(),
+         f4 = 7}).
+
+-type r0() :: #r0{} | #r{f1 :: 3} | #r{f1 :: 3, f2 :: 'sju'}.
+
+-type m1() :: #{}.
+-type m2() :: #{a => m1(), b => #{} | fy:m2()}.
+-type b1() :: B1 :: binary() | (BitString :: bitstring()).
+
+-define(PAIR(A, B), {(A), (B)}).
+
+-spec igor_type_specs:f({r0(), r0()}) -> {t(), t()}.
+
+f({R, R}) ->
+    _ = "igor_type_specs" ++ "hej",
+    _ = <<"foo">>,
+    _ = R#r.f1,
+    _ = R#r{f1 = 17, f2 = b},
+    {1, 1}.
+
+-spec igor_type_specs:b() -> integer() | fun().
+
+b() ->
+    case foo:bar() of
+        #{a := 2} -> 19
+    end.
+
+-spec c(Atom :: atom(), Integer :: integer()) -> {atom(), integer()};
+       (X, Y) -> {atom(), float()} when X :: atom(),
+                                        is_subtype(Y, float());
+       (integer(), atom()) -> {integer(), atom()}.
+
+c(A, B) ->
+    _ = integer,
+    {A, B}.

--- a/test_app/src/m1.erl
+++ b/test_app/src/m1.erl
@@ -1,0 +1,22 @@
+%%
+%% File:    m1.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-24
+%%
+
+-module(m1).
+
+-export([foo/0,bar/1,baz/2]).
+
+foo() ->
+    [m2:foo(),
+     m2:bar()].
+
+bar(A) ->
+    [m2:foo(A),
+     m2:bar(A),
+     m2:record_update(3,m2:record())].
+
+baz(A,B) ->
+    [m2:foo(A,B),
+     m2:bar(A,B)].

--- a/test_app/src/m2.erl
+++ b/test_app/src/m2.erl
@@ -1,0 +1,26 @@
+%%
+%% File:    m2.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-24
+%%
+
+-module(m2).
+
+
+-export([foo/0,foo/1,foo/2,
+	 bar/0,bar/1,bar/2,
+	 record_update/2, record/0]).
+
+foo() -> ok.
+foo(A) -> [item,A].
+foo(A,B) -> A + B.
+
+bar() -> true.
+bar(A) -> {element,A}.
+bar(A,B) -> A*B.
+
+-record(rec, {a,b}).
+
+record() -> #rec{a=3,b=0}.
+record_update(V,#rec{a=V0}=R) ->
+    R#rec{a=V0+V,b=V0}.

--- a/test_app/src/macros.erl
+++ b/test_app/src/macros.erl
@@ -1,3 +1,8 @@
+%%
+%% File:    syntax_tools_test.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-23
+%%
 -module(macros).
 
 -define(ADULT_AGE, 21).
@@ -17,4 +22,11 @@ is_adult_test() ->
     ?assertNot(is_adult(?NEW_PERSON("test2", 12))),
     ?assert(is_adult(?SOMEONE)).
 
+-endif.
+
+-if(A_BOOLEAN_MACRO).
+another_hidden_function() ->
+        % string combining ?
+
+        is_hidden.
 -endif.

--- a/test_app/src/macros.erl
+++ b/test_app/src/macros.erl
@@ -1,8 +1,3 @@
-%%
-%% File:    syntax_tools_test.erl
-%% Author:  Björn-Egil Dahlberg
-%% Created: 2014-10-23
-%%
 -module(macros).
 
 -define(ADULT_AGE, 21).

--- a/test_app/src/others.erl
+++ b/test_app/src/others.erl
@@ -1,0 +1,52 @@
+-module(others).
+
+-compile(export_all).
+
+strange_infix_operators(A, B) ->
+    bnot (-(A rem B)).
+
+-define(OUT_OF_CONTEXT_CLAUSE, true -> false).
+
+-record(rec, {key, value}).
+
+named_fun_expr() ->
+    fun This(is) -> a;
+        This(recursive) -> function;
+        This(called) -> This(is)
+    end.
+
+catch_expr() ->
+    catch this:train(with, all, its, arguments, {they, might, be, too, many, to, "handle"}).
+
+comprehensions(Bin, List) ->
+    BinToBin = << <<X:1>> || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
+    BinToList = [ X || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X)],
+    ListToBin = << <<X:1>> || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
+    ListToList = [ X || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X)],
+    {BinToBin, BinToList, ListToBin, ListToList}.
+
+parentheses() ->
+    ({"does                            ", this, ([([code, <<"        look         ">>, like]), "lisp", (((to))), (([{[((<<"(      you or me or them?)">>))]}]))])}).
+
+receive_expr() ->
+    receive
+        with -> {no, timeout}
+    end.
+
+record_index_expr(List) ->
+    lists:keyfind(a, #rec.key, List).
+
+try_expr_after() ->
+    try to:open({the, door}) of
+        my -> room or your;
+        room -> {my, friend}
+    catch
+        {you_cant, Open} when Open ->
+            it:was(Open)
+    after
+        close:the(door, anyway)
+    end,
+    try with:no(catching)
+    after
+        do:something({to, "clean up", <<"the">>, [filthy, filthy, mess], you, created, "if you can"})
+    end.

--- a/test_app/src/others.erl
+++ b/test_app/src/others.erl
@@ -50,3 +50,21 @@ try_expr_after() ->
     after
         do:something({to, "clean up", <<"the">>, [filthy, filthy, mess], you, created, "if you can"})
     end.
+
+bit_types(X) ->
+    <<X:4/little-signed-integer-unit:8, (something:on(X)):32/big-unsigned-integer-unit:32>>.
+
+numbers() ->
+    {
+        1.00000000001,
+        1.0000001,
+        1.001,
+        16#FFFFFFFF,
+        2#101010101,
+        8#11111,
+        -1.0e+001,
+        0.5e-1,
+        12312.231234e12,
+        1.2e-0,
+        1.2e-000001
+    }.

--- a/test_app/src/specs_and_funs.erl
+++ b/test_app/src/specs_and_funs.erl
@@ -1,0 +1,18 @@
+-module(specs_and_funs).
+
+-export([my_apply/3, two/1]).
+
+%% OTP-15519, ERL-815
+
+-spec my_apply(Fun, Arg, fun((A) -> A)) -> Result when
+      Fun :: fun((Arg) -> Result),
+      Arg :: any(),
+      Result :: any().
+
+my_apply(Fun, Arg, _) ->
+    Fun(Arg).
+
+-spec two(fun((A) -> A)) -> fun((B) -> B).
+
+two(F) ->
+    F(fun(X) -> X end).

--- a/test_app/src/syntax_tools_SUITE_test_module.erl
+++ b/test_app/src/syntax_tools_SUITE_test_module.erl
@@ -1,0 +1,540 @@
+-module(syntax_tools_SUITE_test_module).
+
+-export([foo1/1,foo2/3,start_child/2]).
+
+-export([len/1,equal/2,concat/2,chr/2,rchr/2,str/2,rstr/2,
+	 span/2,cspan/2,substr/2,substr/3,tokens/2,chars/2,chars/3]).
+-export([copies/2,words/1,words/2,strip/1,strip/2,strip/3,
+	 sub_word/2,sub_word/3,left/2,left/3,right/2,right/3,
+	 sub_string/2,sub_string/3,centre/2,centre/3, join/2]).
+-export([to_upper/1, to_lower/1]).
+
+-import(lists,[reverse/1,member/2]).
+
+
+%% @type some_type() = map()
+%% @type some_other_type() = {a, #{ list() => term()}}
+
+-type some_type() :: map().
+-type some_other_type() :: {'a', #{ list() => term()} }.
+
+-spec foo1(Map :: #{ 'a' => integer(), 'b' => term()}) -> term().
+
+%% @doc Gets value from map.
+
+foo1(#{ a:= 1, b := V}) -> V.
+
+%% @spec foo2(some_type(), Type2 :: some_other_type(), map()) -> Value
+%% @doc Gets value from map.
+
+-spec foo2(
+    Type1 :: some_type(),
+    Type2 :: some_other_type(),
+    Map :: #{ get => 'value', 'value' => binary()}) -> binary().
+
+foo2(Type1, {a,#{ "a" := _}}, #{get := value, value := B}) when is_map(Type1) -> B.
+
+%% from supervisor 18.0
+
+-type child()    :: 'undefined' | pid().
+-type child_id() :: term().
+-type mfargs()   :: {M :: module(), F :: atom(), A :: [term()] | undefined}.
+-type modules()  :: [module()] | 'dynamic'.
+-type restart()  :: 'permanent' | 'transient' | 'temporary'.
+-type shutdown() :: 'brutal_kill' | timeout().
+-type worker()   :: 'worker' | 'supervisor'.
+-type sup_ref()  :: (Name :: atom())
+                  | {Name :: atom(), Node :: node()}
+                  | {'global', Name :: atom()}
+                  | {'via', Module :: module(), Name :: any()}
+                  | pid().
+-type child_spec() :: #{name => child_id(),     % mandatory
+			start => mfargs(),      % mandatory
+			restart => restart(),   % optional
+			shutdown => shutdown(), % optional
+			type => worker(),       % optional
+			modules => modules()}   % optional
+                    | {Id :: child_id(),
+                       StartFunc :: mfargs(),
+                       Restart :: restart(),
+                       Shutdown :: shutdown(),
+                       Type :: worker(),
+                       Modules :: modules()}.
+
+-type startchild_err() :: 'already_present'
+			| {'already_started', Child :: child()} | term().
+-type startchild_ret() :: {'ok', Child :: child()}
+                        | {'ok', Child :: child(), Info :: term()}
+			| {'error', startchild_err()}.
+
+
+-spec start_child(SupRef, ChildSpec) -> startchild_ret() when
+      SupRef :: sup_ref(),
+      ChildSpec :: child_spec() | (List :: [term()]).
+start_child(Supervisor, ChildSpec) ->
+    {Supervisor,ChildSpec}.
+
+
+%% From string.erl
+%% Robert's bit
+
+%% len(String)
+%%  Return the length of a string.
+
+-spec len(String) -> Length when
+      String :: string(),
+      Length :: non_neg_integer().
+
+len(S) -> length(S).
+
+%% equal(String1, String2)
+%%  Test if 2 strings are equal.
+
+-spec equal(String1, String2) -> boolean() when
+      String1 :: string(),
+      String2 :: string().
+
+equal(S, S) -> true;
+equal(_, _) -> false.
+
+%% concat(String1, String2)
+%%  Concatenate 2 strings.
+
+-spec concat(String1, String2) -> String3 when
+      String1 :: string(),
+      String2 :: string(),
+      String3 :: string().
+
+concat(S1, S2) -> S1 ++ S2.
+
+%% chr(String, Char)
+%% rchr(String, Char)
+%%  Return the first/last index of the character in a string.
+
+-spec chr(String, Character) -> Index when
+      String :: string(),
+      Character :: char(),
+      Index :: non_neg_integer().
+
+chr(S, C) when is_integer(C) -> chr(S, C, 1).
+
+chr([C|_Cs], C, I) -> I;
+chr([_|Cs], C, I) -> chr(Cs, C, I+1);
+chr([], _C, _I) -> 0.
+
+-spec rchr(String, Character) -> Index when
+      String :: string(),
+      Character :: char(),
+      Index :: non_neg_integer().
+
+rchr(S, C) when is_integer(C) -> rchr(S, C, 1, 0).
+
+rchr([C|Cs], C, I, _L) ->			%Found one, now find next!
+    rchr(Cs, C, I+1, I);
+rchr([_|Cs], C, I, L) ->
+    rchr(Cs, C, I+1, L);
+rchr([], _C, _I, L) -> L.
+
+%% str(String, SubString)
+%% rstr(String, SubString)
+%% index(String, SubString)
+%%  Return the first/last index of the sub-string in a string.
+%%  index/2 is kept for backwards compatibility.
+
+-spec str(String, SubString) -> Index when
+      String :: string(),
+      SubString :: string(),
+      Index :: non_neg_integer().
+
+str(S, Sub) when is_list(Sub) -> str(S, Sub, 1).
+
+str([C|S], [C|Sub], I) ->
+    case prefix(Sub, S) of
+	true -> I;
+	false -> str(S, [C|Sub], I+1)
+    end;
+str([_|S], Sub, I) -> str(S, Sub, I+1);
+str([], _Sub, _I) -> 0.
+
+-spec rstr(String, SubString) -> Index when
+      String :: string(),
+      SubString :: string(),
+      Index :: non_neg_integer().
+
+rstr(S, Sub) when is_list(Sub) -> rstr(S, Sub, 1, 0).
+
+rstr([C|S], [C|Sub], I, L) ->
+    case prefix(Sub, S) of
+	true -> rstr(S, [C|Sub], I+1, I);
+	false -> rstr(S, [C|Sub], I+1, L)
+    end;
+rstr([_|S], Sub, I, L) -> rstr(S, Sub, I+1, L);
+rstr([], _Sub, _I, L) -> L.
+
+prefix([C|Pre], [C|String]) -> prefix(Pre, String);
+prefix([], String) when is_list(String) -> true;
+prefix(Pre, String) when is_list(Pre), is_list(String) -> false.
+
+%% span(String, Chars) -> Length.
+%% cspan(String, Chars) -> Length.
+
+-spec span(String, Chars) -> Length when
+      String :: string(),
+      Chars :: string(),
+      Length :: non_neg_integer().
+
+span(S, Cs) when is_list(Cs) -> span(S, Cs, 0).
+
+span([C|S], Cs, I) ->
+    case member(C, Cs) of
+	true -> span(S, Cs, I+1);
+	false -> I
+    end;
+span([], _Cs, I) -> I.
+
+-spec cspan(String, Chars) -> Length when
+      String :: string(),
+      Chars :: string(),
+      Length :: non_neg_integer().
+
+cspan(S, Cs) when is_list(Cs) -> cspan(S, Cs, 0).
+
+cspan([C|S], Cs, I) ->
+    case member(C, Cs) of
+	true -> I;
+	false -> cspan(S, Cs, I+1)
+    end;
+cspan([], _Cs, I) -> I.
+
+%% substr(String, Start)
+%% substr(String, Start, Length)
+%%  Extract a sub-string from String.
+
+-spec substr(String, Start) -> SubString when
+      String :: string(),
+      SubString :: string(),
+      Start :: pos_integer().
+
+substr(String, 1) when is_list(String) -> 
+    String;
+substr(String, S) when is_integer(S), S > 1 ->
+    substr2(String, S).
+
+-spec substr(String, Start, Length) -> SubString when
+      String :: string(),
+      SubString :: string(),
+      Start :: pos_integer(),
+      Length :: non_neg_integer().
+
+substr(String, S, L) when is_integer(S), S >= 1, is_integer(L), L >= 0 ->
+    substr1(substr2(String, S), L).
+
+substr1([C|String], L) when L > 0 -> [C|substr1(String, L-1)];
+substr1(String, _L) when is_list(String) -> [].	     %Be nice!
+
+substr2(String, 1) when is_list(String) -> String;
+substr2([_|String], S) -> substr2(String, S-1).
+
+%% tokens(String, Seperators).
+%%  Return a list of tokens seperated by characters in Seperators.
+
+-spec tokens(String, SeparatorList) -> Tokens when
+      String :: string(),
+      SeparatorList :: string(),
+      Tokens :: [Token :: nonempty_string()].
+
+tokens(S, Seps) ->
+    tokens1(S, Seps, []).
+
+tokens1([C|S], Seps, Toks) ->
+    case member(C, Seps) of
+	true -> tokens1(S, Seps, Toks);
+	false -> tokens2(S, Seps, Toks, [C])
+    end;
+tokens1([], _Seps, Toks) ->
+    reverse(Toks).
+
+tokens2([C|S], Seps, Toks, Cs) ->
+    case member(C, Seps) of
+	true -> tokens1(S, Seps, [reverse(Cs)|Toks]);
+	false -> tokens2(S, Seps, Toks, [C|Cs])
+    end;
+tokens2([], _Seps, Toks, Cs) ->
+    reverse([reverse(Cs)|Toks]).
+
+-spec chars(Character, Number) -> String when
+      Character :: char(),
+      Number :: non_neg_integer(),
+      String :: string().
+
+chars(C, N) -> chars(C, N, []).
+
+-spec chars(Character, Number, Tail) -> String when
+      Character :: char(),
+      Number :: non_neg_integer(),
+      Tail :: string(),
+      String :: string().
+
+chars(C, N, Tail) when N > 0 ->
+    chars(C, N-1, [C|Tail]);
+chars(C, 0, Tail) when is_integer(C) ->
+    Tail.
+
+%% Torbjörn's bit.
+
+%%% COPIES %%%
+
+-spec copies(String, Number) -> Copies when
+      String :: string(),
+      Copies :: string(),
+      Number :: non_neg_integer().
+
+copies(CharList, Num) when is_list(CharList), is_integer(Num), Num >= 0 ->
+    copies(CharList, Num, []).
+
+copies(_CharList, 0, R) ->
+    R;
+copies(CharList, Num, R) ->
+    copies(CharList, Num-1, CharList++R).
+
+%%% WORDS %%%
+
+-spec words(String) -> Count when
+      String :: string(),
+      Count :: pos_integer().
+
+words(String) -> words(String, $\s).
+
+-spec words(String, Character) -> Count when
+      String :: string(),
+      Character :: char(),
+      Count :: pos_integer().
+
+words(String, Char) when is_integer(Char) ->
+    w_count(strip(String, both, Char), Char, 0).
+
+w_count([], _, Num) -> Num+1;
+w_count([H|T], H, Num) -> w_count(strip(T, left, H), H, Num+1);
+w_count([_H|T], Char, Num) -> w_count(T, Char, Num).
+
+%%% SUB_WORDS %%%
+
+-spec sub_word(String, Number) -> Word when
+      String :: string(),
+      Word :: string(),
+      Number :: integer().
+
+sub_word(String, Index) -> sub_word(String, Index, $\s).
+
+-spec sub_word(String, Number, Character) -> Word when
+      String :: string(),
+      Word :: string(),
+      Number :: integer(),
+      Character :: char().
+
+sub_word(String, Index, Char) when is_integer(Index), is_integer(Char) ->
+    case words(String, Char) of
+	Num when Num < Index ->
+	    [];
+	_Num ->
+	    s_word(strip(String, left, Char), Index, Char, 1, [])
+    end.
+
+s_word([], _, _, _,Res) -> reverse(Res);
+s_word([Char|_],Index,Char,Index,Res) -> reverse(Res);
+s_word([H|T],Index,Char,Index,Res) -> s_word(T,Index,Char,Index,[H|Res]);
+s_word([Char|T],Stop,Char,Index,Res) when Index < Stop -> 
+    s_word(strip(T,left,Char),Stop,Char,Index+1,Res);
+s_word([_|T],Stop,Char,Index,Res) when Index < Stop -> 
+    s_word(T,Stop,Char,Index,Res).
+
+%%% STRIP %%%
+
+-spec strip(string()) -> string().
+
+strip(String) -> strip(String, both).
+
+-spec strip(String, Direction) -> Stripped when
+      String :: string(),
+      Stripped :: string(),
+      Direction :: left | right | both.
+
+strip(String, left) -> strip_left(String, $\s);
+strip(String, right) -> strip_right(String, $\s);
+strip(String, both) ->
+    strip_right(strip_left(String, $\s), $\s).
+
+-spec strip(String, Direction, Character) -> Stripped when
+      String :: string(),
+      Stripped :: string(),
+      Direction :: left | right | both,
+      Character :: char().
+
+strip(String, right, Char) -> strip_right(String, Char);
+strip(String, left, Char) -> strip_left(String, Char);
+strip(String, both, Char) ->
+    strip_right(strip_left(String, Char), Char).
+
+strip_left([Sc|S], Sc) ->
+    strip_left(S, Sc);
+strip_left([_|_]=S, Sc) when is_integer(Sc) -> S;
+strip_left([], Sc) when is_integer(Sc) -> [].
+
+strip_right([Sc|S], Sc) ->
+    case strip_right(S, Sc) of
+	[] -> [];
+	T  -> [Sc|T]
+    end;
+strip_right([C|S], Sc) ->
+    [C|strip_right(S, Sc)];
+strip_right([], Sc) when is_integer(Sc) ->
+    [].
+
+%%% LEFT %%%
+
+-spec left(String, Number) -> Left when
+      String :: string(),
+      Left :: string(),
+      Number :: non_neg_integer().
+
+left(String, Len) when is_integer(Len) -> left(String, Len, $\s).
+
+-spec left(String, Number, Character) -> Left when
+      String :: string(),
+      Left :: string(),
+      Number :: non_neg_integer(),
+      Character :: char().
+
+left(String, Len, Char) when is_integer(Char) ->
+    Slen = length(String),
+    if
+	Slen > Len -> substr(String, 1, Len);
+	Slen < Len -> l_pad(String, Len-Slen, Char);
+	Slen =:= Len -> String
+    end.
+
+l_pad(String, Num, Char) -> String ++ chars(Char, Num).
+
+%%% RIGHT %%%
+
+-spec right(String, Number) -> Right when
+      String :: string(),
+      Right :: string(),
+      Number :: non_neg_integer().
+
+right(String, Len) when is_integer(Len) -> right(String, Len, $\s).
+
+-spec right(String, Number, Character) -> Right when
+      String :: string(),
+      Right :: string(),
+      Number :: non_neg_integer(),
+      Character :: char().
+
+right(String, Len, Char) when is_integer(Char) ->
+    Slen = length(String),
+    if
+	Slen > Len -> substr(String, Slen-Len+1);
+	Slen < Len -> r_pad(String, Len-Slen, Char);
+	Slen =:= Len -> String
+    end.
+
+r_pad(String, Num, Char) -> chars(Char, Num, String).
+
+%%% CENTRE %%%
+
+-spec centre(String, Number) -> Centered when
+      String :: string(),
+      Centered :: string(),
+      Number :: non_neg_integer().
+
+centre(String, Len) when is_integer(Len) -> centre(String, Len, $\s).
+
+-spec centre(String, Number, Character) -> Centered when
+      String :: string(),
+      Centered :: string(),
+      Number :: non_neg_integer(),
+      Character :: char().
+
+centre(String, 0, Char) when is_list(String), is_integer(Char) ->
+    [];                       % Strange cases to centre string
+centre(String, Len, Char) when is_integer(Char) ->
+    Slen = length(String),
+    if
+	Slen > Len -> substr(String, (Slen-Len) div 2 + 1, Len);
+	Slen < Len ->
+	    N = (Len-Slen) div 2,
+	    r_pad(l_pad(String, Len-(Slen+N), Char), N, Char);
+	Slen =:= Len -> String
+    end.
+
+%%% SUB_STRING %%%
+
+-spec sub_string(String, Start) -> SubString when
+      String :: string(),
+      SubString :: string(),
+      Start :: pos_integer().
+
+sub_string(String, Start) -> substr(String, Start).
+
+-spec sub_string(String, Start, Stop) -> SubString when
+      String :: string(),
+      SubString :: string(),
+      Start :: pos_integer(),
+      Stop :: pos_integer().
+
+sub_string(String, Start, Stop) -> substr(String, Start, Stop - Start + 1).
+
+%% ISO/IEC 8859-1 (latin1) letters are converted, others are ignored
+%%
+
+to_lower_char(C) when is_integer(C), $A =< C, C =< $Z ->
+    C + 32;
+to_lower_char(C) when is_integer(C), 16#C0 =< C, C =< 16#D6 ->
+    C + 32;
+to_lower_char(C) when is_integer(C), 16#D8 =< C, C =< 16#DE ->
+    C + 32;
+to_lower_char(C) ->
+    C.
+
+to_upper_char(C) when is_integer(C), $a =< C, C =< $z ->
+    C - 32;
+to_upper_char(C) when is_integer(C), 16#E0 =< C, C =< 16#F6 ->
+    C - 32;
+to_upper_char(C) when is_integer(C), 16#F8 =< C, C =< 16#FE ->
+    C - 32;
+to_upper_char(C) ->
+    C.
+
+-spec to_lower(String) -> Result when
+                  String :: io_lib:latin1_string(),
+                  Result :: io_lib:latin1_string()
+	    ; (Char) -> CharResult when
+                  Char :: char(),
+                  CharResult :: char().
+
+to_lower(S) when is_list(S) ->
+    [to_lower_char(C) || C <- S];
+to_lower(C) when is_integer(C) ->
+    to_lower_char(C).
+
+-spec to_upper(String) -> Result when
+                  String :: io_lib:latin1_string(),
+                  Result :: io_lib:latin1_string()
+	    ; (Char) -> CharResult when
+                  Char :: char(),
+                  CharResult :: char().
+
+to_upper(S) when is_list(S) ->
+    [to_upper_char(C) || C <- S];
+to_upper(C) when is_integer(C) ->
+    to_upper_char(C).
+
+-spec join(StringList, Separator) -> String when
+      StringList :: [string()],
+      Separator :: string(),
+      String :: string().
+
+join([], Sep) when is_list(Sep) ->
+    [];
+join([H|T], Sep) ->
+    H ++ lists:append([Sep ++ X || X <- T]).

--- a/test_app/src/syntax_tools_test.erl
+++ b/test_app/src/syntax_tools_test.erl
@@ -1,0 +1,116 @@
+%%
+%% File:    syntax_tools_test.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-10-23
+%%
+
+-module(syntax_tools_test).
+
+-export([foo1/0,foo2/2,foo3/0,foo4/3,foo5/1]).
+
+-include_lib("kernel/include/file.hrl").
+-record(state, { a, b, c, d}).
+-attribute([foo/0]).
+
+%% @todo handle this https://github.com/AdRoll/rebar3_format/issues/22
+% -define(attrib, some_attrib).
+% -?attrib([foo2/2]).
+
+-define(macro_simple1, ok).
+-define(MACRO_SIMPLE2, (other)).
+-define(macro_simple3, ?MODULE).
+-define(macro_simple4, [?macro_simple3,?MODULE,?MACRO_SIMPLE2]).
+-define(macro_simple5, (process_info)).
+-define(macro_string, "hello world").
+-define(macro_argument1(X), (X + 3)).
+-define(macro_argument2(X,Y), (X + 3 * Y)).
+-define(macro_block(X), begin X end).
+-define(macro_if(X1,X2), if X1 -> X2; true -> none end).
+
+
+-ifdef(macro_def1).
+-define(macro_cond1, yep).
+-else.
+-define(macro_cond1, nope).
+-endif.
+-ifndef(macro_def2).
+-define(macro_cond2, nope).
+-else.
+-define(macro_cond2, yep).
+-endif.
+-undef(macro_def1).
+-undef(macro_def2).
+
+%% basic test
+foo1() ->
+    ok.
+
+%% macro test
+foo2(A,B) ->
+%% @todo handle string combining
+%%       https://github.com/AdRoll/rebar3_format/issues/22
+%%    [?macro_string ?macro_string,
+    [?macro_string,
+     "hello world "
+     "more hello",
+     [?macro_simple1,
+      ?MACRO_SIMPLE2,
+      ?macro_simple3,
+      ?macro_simple4,
+      ?macro_simple5,
+      ?macro_string,
+      ?macro_cond1,
+      ?macro_cond2,
+      ?macro_block(A),
+      ?macro_if(A,B),
+      ?macro_argument1(A),
+      ?macro_argument1(begin A end),
+      ?macro_block(<<"hello">>),
+      ?macro_block("hello"),
+      ?macro_block([$h,$e,$l,$l,$0]),
+      ?macro_argument1(id(<<"hello">>)),
+      ?macro_argument1(if A -> B; true -> 3.14 end),
+      ?macro_argument1(case A of ok -> B; C -> C end),
+      ?macro_argument1(receive M -> M after 100 -> 3 end),
+      ?macro_argument1(try foo5(A) catch C:?macro_simple5 -> {C,B} end),
+      ?macro_argument2(A,B)],
+     A,B,ok].
+
+id(I) -> I.
+%% basic terms
+
+foo3() ->
+    [atom,
+     'some other atom',
+     {tuple,1,2,3},
+     1,2,3,3333,
+     3,3333,2,1,
+     [$a,$b,$c],
+     "hello world",
+     <<"hello world">>,
+     <<1,2,3,4,5:6>>,
+     3.1415,
+     1.03e33].
+
+%% application and records
+
+foo4(A,B,#state{c = C}=S) ->
+    Ls = foo3(),
+    S1 = #state{ a = 1, b = 2 },
+    [foo2(A,Ls),B,C,
+     B(3,C),
+     erlang:process_info(self()),
+     erlang:?macro_simple5(self()),
+     A:?MACRO_SIMPLE2(),
+     A:?macro_simple1(),
+     A:process_info(self()),
+     A:B(3),
+     S#state{ a = 2, b = B, d = S1 }].
+
+foo5(A) ->
+    try foo2(A,A) of
+	R -> R
+    catch
+	error:?macro_simple5 ->
+	    nope
+    end.

--- a/test_app/src/type_specs.erl
+++ b/test_app/src/type_specs.erl
@@ -1,0 +1,87 @@
+-module(type_specs).
+
+-include_lib("syntax_tools/include/merl.hrl").
+
+-export([f/1, b/0, c/2]).
+
+-export_type([t/0, ot/2, ff2/0]).
+
+-type aa() :: _.
+
+-type t() :: integer().
+
+-type ff(A) :: ot(A, A) | tuple() | 1..3 | map() | {}.
+-type ff1() :: ff(bin()) | foo:bar().
+-type ff2() :: {list(), [_], list(integer()),
+                nonempty_list(), nonempty_list(atom()), [ff1(), ...],
+                nil(), []}.
+-type bin() :: <<>>
+             | <<_:(+4)>>
+             | <<_:_*8>>
+             | <<_:12, _:_*16>>
+             | <<_:16, _:_*(0)>> % same as "<<_:16>>"
+             | <<_:16, _:_*(+0)>>.
+
+-callback cb() -> t().
+
+-optional_callbacks([cb/0]).
+
+-opaque ot(A, B) :: {A, B}.
+
+-type f1() :: fun().
+-type f2() :: fun((...) -> t()).
+-type f3() :: fun(() -> t()).
+-type f4() :: fun((t(), t()) -> t()).
+
+-wild(attribute).
+
+-record(par, {a :: undefined | ?MODULE}).
+
+-record(r0, {}).
+
+-record(r,
+        {f1 :: integer(),
+         f2 = a :: atom(),
+         f3 :: fun(),
+         f4 = 7}).
+
+-type r0() :: #r0{} | #r{f1 :: 3} | #r{f1 :: 3, f2 :: 'sju'}.
+
+-type m1() :: #{} | map().
+-type m2() :: #{a := m1(), b => #{} | fy:m2()}.
+%-type m3() :: #{...}.
+%-type m4() :: #{_ => _, ...}.
+%-type m5() :: #{any() => any(), ...}.
+-type m3() :: #{any() => any()}.
+-type m4() :: #{_ => _, any() => any()}.
+-type m5() :: #{any() => any(), any() => any()}.
+-type b1() :: B1 :: binary() | (BitString :: bitstring()).
+
+-define(PAIR(A, B), {(A), (B)}).
+
+-spec ?MODULE:f(?PAIR(r0(), r0())) -> ?PAIR(t(), t()).
+
+f({R, R}) ->
+    _ = ?MODULE_STRING ++ "hej",
+    _ = <<"foo">>,
+    _ = R#r.f1,
+    _ = R#r{f1 = 17, f2 = b},
+    {1, 1}.
+
+-spec ?MODULE:b() -> integer() | fun().
+
+b() ->
+    case foo:bar() of
+        #{a := 2} -> 19
+    end.
+
+-define(I, integer).
+
+-spec c(Atom :: atom(), Integer :: ?I()) -> {atom(), integer()};
+       (X, Y) -> {atom(), float()} when X :: atom(),
+                                        is_subtype(Y, float());
+       (integer(), atom()) -> {integer(), atom()}.
+
+c(A, B) ->
+    _ = ?I,
+    {A, B}.


### PR DESCRIPTION
In this PR I had…
* copied the tests from OTP's `syntax_tools` app.
* removed some unused code from `rebar3_prettypr`.
* added enough weird examples to cover most if not all of the module's code paths.

I reached 91% coverage… the remaining 9% is full of irreproducible edge-cases and catch-all clauses that are never evaluated _in our world_.