### PR TITLE
Recover the linting as a plugin, once rebar3_lint uses katana_code 0.2.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
     {katana_code, "0.2.1"}
 ]}.
 
-{plugins, [rebar3_hex]}.
+{plugins, [rebar3_lint, rebar3_hex]}.
 
 {dialyzer, [
     {warnings, [no_return, unmatched_returns, error_handling, underspecs]},
@@ -38,6 +38,6 @@
 
 {cover_opts, [verbose]}.
 
-{alias, [{test, [dialyzer, ct, cover]}]}.
+{alias, [{test, [lint, dialyzer, ct, cover]}]}.
 
 {post_hooks, [{compile, "escript priv/scripts/format"}]}.


### PR DESCRIPTION
Right now rebar3_lint uses an older version of the katana-code library. 