### PR TITLE
Fix #32: don't put more one item per row

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The plugin supports the following configuration options in the `format` section 
 * `remove_trailing_spaces` (`boolean()`):
     - If this setting is `true`, the formatter will remove all trailing whitespaces.
     - The default value is `true`.
+* `inline_items` (`boolean()`):
+    - Specifies the desired behavior when using multiple lines for a multi-item structure (i.e. tuple, list, map, etc.).
+    - When this flag is on, the formatter will try to fit as many items in each line as permitted by `paper` and `ribbon`.
+    - When the flag is off, the formatter will place each item in its own line.
+    - The default value is `true`.
 * `inline_expressions` (`boolean()`):
     - Specifies if sequential expressions in a clause should be placed in the same line if `paper` and `ribbon` allows it or if each expression should be placed in its own line.
     - The default value is `true`.

--- a/src/rebar3_formatter.erl
+++ b/src/rebar3_formatter.erl
@@ -7,8 +7,8 @@
                   output_dir => undefined | string(), encoding => none | epp:source_encoding(),
                   paper => pos_integer(), ribbon => pos_integer(), break_indent => pos_integer(),
                   sub_indent => pos_integer(), remove_tabs => boolean(),
-                  remove_trailing_spaces => boolean(), inline_expressions => boolean(),
-                  preserve_empty_lines => boolean()}.
+                  remove_trailing_spaces => boolean(), inline_items => boolean(),
+                  inline_expressions => boolean(), preserve_empty_lines => boolean()}.
 
 -export_type([opts/0]).
 
@@ -49,6 +49,7 @@ format(File, AST, Comments, Opts) ->
     SubIndent = maps:get(sub_indent, Opts, 2),
     RemoveTabs = maps:get(remove_tabs, Opts, true),
     RemoveTrailingSpaces = maps:get(remove_trailing_spaces, Opts, true),
+    InlineItems = maps:get(inline_items, Opts, true),
     InlineExpressions = maps:get(inline_expressions, Opts, true),
     PreserveEmptyLines = maps:get(preserve_empty_lines, Opts, false),
     FinalFile = case maps:get(output_dir, Opts) of
@@ -58,7 +59,7 @@ format(File, AST, Comments, Opts) ->
     ok = filelib:ensure_dir(FinalFile),
     FormatOpts = [{paper, Paper}, {ribbon, Ribbon}, {encoding, Encoding},
                   {break_indent, BreakIndent}, {sub_indent, SubIndent},
-                  {inline_expressions, InlineExpressions}],
+                  {inline_items, InlineItems}, {inline_expressions, InlineExpressions}],
     ExtendedAST = AST ++ [{eof, 0}],
     WithComments = erl_recomment:recomment_forms(erl_syntax:form_list(ExtendedAST),
                                                  Comments),

--- a/src/rebar3_prettypr.erl
+++ b/src/rebar3_prettypr.erl
@@ -357,9 +357,8 @@ lay_no_comments(Node, Ctxt) ->
           beside(D1, D2);
       block_expr ->
           Ctxt1 = reset_prec(Ctxt),
-          Es = seq(erl_syntax:block_expr_body(Node), lay_text_float(","), Ctxt1,
-                   fun lay/2),
-          sep([text("begin"), nest(Ctxt1#ctxt.sub_indent, sep(Es)), text("end")]);
+          Es = lay_clause_expressions(erl_syntax:block_expr_body(Node), Ctxt1, fun lay/2),
+          sep([text("begin"), nest(Ctxt1#ctxt.sub_indent, Es), text("end")]);
       catch_expr ->
           {Prec, PrecR} = preop_prec('catch'),
           D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
@@ -449,8 +448,8 @@ lay_no_comments(Node, Ctxt) ->
                  none -> D1;
                  T ->
                      D3 = lay(T, Ctxt1),
-                     A = erl_syntax:receive_expr_action(Node),
-                     D4 = sep(seq(A, lay_text_float(","), Ctxt1, fun lay/2)),
+                     D4 = lay_clause_expressions(erl_syntax:receive_expr_action(Node), Ctxt1,
+                                                 fun lay/2),
                      sep([D1,
                           follow(lay_text_float("after"), append_clause_body(D4, D3, Ctxt1),
                                  Ctxt1#ctxt.sub_indent)])
@@ -516,13 +515,12 @@ lay_no_comments(Node, Ctxt) ->
           maybe_parentheses(D3, Prec, Ctxt);
       try_expr ->
           Ctxt1 = reset_prec(Ctxt),
-          D1 = sep(seq(erl_syntax:try_expr_body(Node), lay_text_float(","), Ctxt1,
-                       fun lay/2)),
+          D1 = lay_clause_expressions(erl_syntax:try_expr_body(Node), Ctxt1, fun lay/2),
           Es0 = [text("end")],
           Es1 = case erl_syntax:try_expr_after(Node) of
                   [] -> Es0;
                   As ->
-                      D2 = sep(seq(As, lay_text_float(","), Ctxt1, fun lay/2)),
+                      D2 = lay_clause_expressions(As, Ctxt1, fun lay/2),
                       [text("after"), nest(Ctxt1#ctxt.sub_indent, D2) | Es0]
                 end,
           Es2 = case erl_syntax:try_expr_handlers(Node) of

--- a/test_app/after/src/inline_items.erl
+++ b/test_app/after/src/inline_items.erl
@@ -1,0 +1,365 @@
+%% @doc All the lists of items in this module should be placed
+%%      in a single line if they're small enough, but one item
+%%      per line if they're large.s
+-module(inline_items).
+
+-record(short_rec, {x, y, z}).
+
+-record(long_rec,
+        {x1 = x1  :: x1,
+         x2 = x2  :: x2,
+         x3 = x3  :: x3,
+         y1 = y1  :: y1,
+         y2 = y2  :: y2,
+         y3 = y3  :: y3,
+         very_very_long_name_1 = very_very_long_name_1  ::
+             very_very_long_name_1,
+         very_very_long_name_2 = very_very_long_name_2  ::
+             very_very_long_name_2,
+         very_very_long_name_3 = very_very_long_name_3  ::
+             very_very_long_name_3}).
+
+-format([{inline_items, false}, {inline_expressions, false}, {paper, 80}]).
+
+-export([short_tuple/0, short_list/0, short_fun/0]).
+
+-export([short_bin/0, short_guard/1, short_lc/0]).
+
+-export([short_bc/0, short_arglist/3, short_rec/0]).
+
+-export([short_map/0]).
+
+-export([long_tuple/0,
+         long_list/0,
+         long_fun/0,
+         long_bin/0,
+         long_guard/1,
+         long_lc/0,
+         long_bc/0,
+         long_arglist/7,
+         long_rec/0,
+         long_map/0]).
+
+-spec short_tuple() -> {T, T, T} when T :: {x, y, z}.
+
+short_tuple() ->
+    X = {x, y, z},
+    Y = {x, y, z},
+    {X, Y, {x, y, z}}.
+
+-spec short_list() -> [T | [T]] when T :: [x | y | z].
+
+short_list() ->
+    X = [x, y, z],
+    Y = [x, y | z],
+    [X, Y, [x | y:z()]].
+
+-spec short_fun() -> fun((X, Y, Z) -> {X, Y, Z}).
+
+short_fun() -> fun (X, Y, Z) -> {X, Y, Z} end.
+
+-spec short_bin() -> binary().
+
+short_bin() ->
+    X = <<1, 2, 3>>,
+    Y = <<1:1, 7:7, 2:2/little-integer-unit:32, 3/float>>,
+    <<X/binary, Y/binary>>.
+
+-spec short_guard(integer()) -> integer().
+
+short_guard(X) when is_integer(X), X < 2 ->
+    case X of
+      X when X >= -1 -> X + 1;
+      X -> X
+    end.
+
+-spec short_lc() -> [{_, _, _}].
+
+short_lc() -> [{X, Y, Z} || {X, Y, Z} <- x:y(z), Z < Y].
+
+-spec short_bc() -> binary().
+
+short_bc() -> << <<X, Y, Z>>  || <<X, Y, Z>> <= x:y(z), Z < Y >>.
+
+-spec short_arglist(number(), number(), number()) -> number().
+
+short_arglist(X, Y, Z) -> X + Y + Z.
+
+-spec short_rec() -> #short_rec{x :: x, y :: y, z :: z}.
+
+short_rec() -> #short_rec{x = x, y = y, z = z}.
+
+-spec short_map() -> #{x => x, y => y, z := z}.
+
+short_map() -> #{x => x, y => y, z => z}.
+
+-spec long_tuple() -> {T, T, T} when T :: {x, y, z}.
+
+long_tuple() ->
+    X = {x1,
+         x2,
+         x3,
+         x4,
+         y1,
+         y2,
+         y3,
+         y4,
+         very_very_long_name_1,
+         very_very_long_name_2,
+         very_very_long_name_3},
+    Y = {x1,
+         x2,
+         x3,
+         x4,
+         y1,
+         y2,
+         y3,
+         y4,
+         very_very_long_name_1,
+         very_very_long_name_2,
+         very_very_long_name_3},
+    {X,
+     Y,
+     {x1,
+      x2,
+      x3,
+      x4,
+      y1,
+      y2,
+      y3,
+      y4,
+      very_very_long_name_1,
+      very_very_long_name_2,
+      very_very_long_name_3}}.
+
+-spec long_list() -> [T | [T]] when T :: [x1 |
+                                          x2 |
+                                          x3 |
+                                          x4 |
+                                          y1 |
+                                          y2 |
+                                          y3 |
+                                          y4 |
+                                          very_very_long_name_1 |
+                                          very_very_long_name_2 |
+                                          very_very_long_name_3].
+
+long_list() ->
+    X = [x1,
+         x2,
+         x3,
+         x4,
+         y1,
+         y2,
+         y3,
+         y4,
+         very_very_long_name_1,
+         very_very_long_name_2,
+         very_very_long_name_3],
+    Y = [x1,
+         x2,
+         x3,
+         x4,
+         y1,
+         y2,
+         y3,
+         y4,
+         very_very_long_name_1,
+         very_very_long_name_2
+         | very_very_long_name_3],
+    [X,
+     Y,
+     [x1,
+      x2,
+      x3,
+      x4,
+      y1,
+      y2,
+      y3,
+      y4,
+      very_very_long_name_1,
+      very_very_long_name_2,
+      very_very_long_name_3
+      | y:z()]].
+
+-spec long_fun() -> fun((X1,
+                         X2,
+                         X3,
+                         X4,
+                         Y1,
+                         Y2,
+                         Y3,
+                         Y4,
+                         VeryVeryLongName1,
+                         VeryVeryLongName2,
+                         VeryVeryLongName3) -> {X1,
+                                                X2,
+                                                X3,
+                                                X4,
+                                                Y1,
+                                                Y2,
+                                                Y3,
+                                                Y4,
+                                                VeryVeryLongName1,
+                                                VeryVeryLongName2,
+                                                VeryVeryLongName3}).
+
+long_fun() ->
+    fun (X1,
+         X2,
+         X3,
+         X4,
+         Y1,
+         Y2,
+         Y3,
+         Y4,
+         VeryVeryLongName1,
+         VeryVeryLongName2,
+         VeryVeryLongName3) ->
+            {X1,
+             X2,
+             X3,
+             X4,
+             Y1,
+             Y2,
+             Y3,
+             Y4,
+             VeryVeryLongName1,
+             VeryVeryLongName2,
+             VeryVeryLongName3}
+    end.
+
+-spec long_bin() -> binary().
+
+long_bin() ->
+    X = <<1,
+          1,
+          1,
+          1,
+          2,
+          2,
+          2,
+          2,
+          333333333333333333,
+          333333333333333333,
+          333333333333333333,
+          333333333333333333>>,
+    Y = <<1:1,
+          1:1,
+          1:1,
+          1:1,
+          4:4,
+          2:2/little-integer-unit:32,
+          2:2/little-integer-unit:32,
+          2:2/little-integer-unit:32,
+          3/float,
+          3/float,
+          3/float,
+          3/float>>,
+    <<X/binary,
+      Y/binary,
+      X/binary,
+      Y/binary,
+      X/binary,
+      Y/binary,
+      X/binary,
+      Y/binary,
+      X/binary,
+      Y/binary>>.
+
+-spec long_guard(integer()) -> integer().
+
+long_guard(VeryVeryLongName)
+    when is_integer(VeryVeryLongName),
+         VeryVeryLongName < 2,
+         VeryVeryLongName < 3;
+         VeryVeryLongName > 2 andalso VeryVeryLongName > 3 ->
+    if VeryVeryLongName >= -1;
+       VeryVeryLongName < 1, VeryVeryLongName > 0;
+       VeryVeryLongName == 0 ->
+           VeryVeryLongName + 1;
+       VeryVeryLongName -> VeryVeryLongName
+    end.
+
+-spec long_lc() -> [{_, _, _}].
+
+long_lc() ->
+    [{X, Y, Z}
+     || X <- generator:x(),
+        X < 1,
+        Y <- generator:y(),
+        Z <- generator:z(),
+        filter:x(Y, Z),
+        X + Y == Z].
+
+-spec long_bc() -> binary().
+
+long_bc() ->
+    << <<X, Y, Z>>
+        || <<X>> <- generator:x(),
+           X < 1,
+           <<Y:2/signed-integer-unit:8>> <- generator:y(),
+           Z <- generator:z(),
+           filter:x(Y, Z),
+           X + Y == Z >>.
+
+-spec long_arglist(number(),
+                   number(),
+                   number(),
+                   float(),
+                   non_neg_integer(),
+                   non_neg_integer(),
+                   non_neg_integer()) -> number().
+
+long_arglist(X1,
+             X2,
+             X3,
+             Y1,
+             VeryVeryLongName1,
+             VeryVeryLongName2,
+             VeryVeryLongName3) ->
+    X1 + X2 + X3 + Y1 + VeryVeryLongName1 + VeryVeryLongName2 +
+      VeryVeryLongName3.
+
+-spec long_rec() -> #long_rec{x1 :: x1,
+                              x2 :: x2,
+                              x3 :: x3,
+                              y1 :: y1,
+                              y2 :: y2,
+                              y3 :: y3,
+                              very_very_long_name_1 :: very_very_long_name_1,
+                              very_very_long_name_2 :: very_very_long_name_2,
+                              very_very_long_name_3 :: very_very_long_name_3}.
+
+long_rec() ->
+    #long_rec{x1 = x1,
+              x2 = x2,
+              x3 = x3,
+              y1 = y1,
+              y2 = y2,
+              y3 = y3,
+              very_very_long_name_1 = very_very_long_name_1,
+              very_very_long_name_2 = very_very_long_name_2,
+              very_very_long_name_3 = very_very_long_name_3}.
+
+-spec long_map() -> #{x1 := x1,
+                      x2 := x2,
+                      x3 := x3,
+                      y1 := y1,
+                      y2 := y2,
+                      y3 := y3,
+                      very_very_long_name_1 := very_very_long_name_1,
+                      very_very_long_name_2 := very_very_long_name_2,
+                      very_very_long_name_3 := very_very_long_name_3}.
+
+long_map() ->
+    #{x1 => x1,
+      x2 => x2,
+      x3 => x3,
+      y1 => y1,
+      y2 => y2,
+      y3 => y3,
+      very_very_long_name_1 => very_very_long_name_1,
+      very_very_long_name_2 => very_very_long_name_2,
+      very_very_long_name_3 => very_very_long_name_3}.
+

--- a/test_app/src/inline_items.erl
+++ b/test_app/src/inline_items.erl
@@ -1,0 +1,163 @@
+%% @doc All the lists of items in this module should be placed
+%%      in a single line if they're small enough, but one item
+%%      per line if they're large.s
+-module inline_items.
+
+-record(short_rec, {x, y, z}).
+-record(long_rec, {
+    x1 = x1 :: x1,
+    x2 = x2 :: x2,
+    x3 = x3 :: x3,
+    y1 = y1 :: y1,
+    y2 = y2 :: y2,
+    y3 = y3 :: y3,
+    very_very_long_name_1 = very_very_long_name_1 :: very_very_long_name_1,
+    very_very_long_name_2 = very_very_long_name_2 :: very_very_long_name_2,
+    very_very_long_name_3 = very_very_long_name_3 :: very_very_long_name_3
+}).
+
+-format [{inline_items, false}, {inline_expressions, false}, {paper, 80}].
+
+-export [short_tuple/0, short_list/0, short_fun/0].
+-export [short_bin/0, short_guard/1, short_lc/0].
+-export [short_bc/0, short_arglist/3, short_rec/0].
+-export [short_map/0].
+
+-export [long_tuple/0, long_list/0, long_fun/0, long_bin/0, long_guard/1, long_lc/0, long_bc/0,
+         long_arglist/7, long_rec/0, long_map/0].
+
+-spec short_tuple() -> {T, T, T} when T :: {x, y, z}.
+short_tuple() ->
+    X = {x, y, z},
+    Y = {x, y, z},
+    {X, Y, {x, y, z}}.
+
+-spec short_list() -> [T | [T]] when T :: [x | y | z].
+short_list() ->
+    X = [x, y, z],
+    Y = [x, y| z],
+    [X, Y, [x | y:z()]].
+
+-spec short_fun() -> fun((X, Y, Z) -> {X, Y, Z}).
+short_fun() ->
+    fun(X,Y,Z) ->
+        {X, Y, Z}
+    end.
+
+-spec short_bin() -> binary().
+short_bin() ->
+    X = <<1, 2, 3>>,
+    Y = <<1:1, 7:7, 2:2/little-integer-unit:32, 3/float>>,
+    <<X/binary, Y/binary>>.
+
+-spec short_guard(integer()) -> integer().
+short_guard(X) when is_integer(X), X < 2 ->
+    case X of
+        X when X >= -1 -> X + 1;
+        X -> X
+    end.
+
+-spec short_lc() -> [{_, _, _}].
+short_lc() ->
+    [{X, Y, Z} || {X, Y, Z} <- x:y(z), Z < Y].
+
+-spec short_bc() -> binary().
+short_bc() ->
+    << <<X, Y, Z>> || <<X, Y, Z>> <= x:y(z), Z < Y >>.
+
+-spec short_arglist(number(), number(), number()) -> number().
+short_arglist(X, Y, Z) -> X+Y+Z.
+
+-spec short_rec() -> #short_rec{x :: x, y :: y, z :: z}.
+short_rec() -> #short_rec{x = x, y = y, z = z}.
+
+-spec short_map() -> #{x => x, y => y, z := z}.
+short_map() -> #{x => x, y => y, z => z}.
+
+
+
+-spec long_tuple() -> {T, T, T} when T :: {x, y, z}.
+long_tuple() ->
+    X = {x1, x2, x3, x4, y1, y2, y3, y4, very_very_long_name_1, very_very_long_name_2, very_very_long_name_3},
+    Y = {x1, x2, x3, x4, y1, y2, y3, y4, very_very_long_name_1, very_very_long_name_2, very_very_long_name_3},
+    {X, Y, {x1, x2, x3, x4, y1, y2, y3, y4, very_very_long_name_1, very_very_long_name_2, very_very_long_name_3}}.
+
+-spec long_list() -> [T | [T]] when T :: [x1 | x2 | x3 | x4 | y1 | y2 | y3 | y4 | very_very_long_name_1 | very_very_long_name_2 | very_very_long_name_3].
+long_list() ->
+    X = [x1, x2, x3, x4, y1, y2, y3, y4, very_very_long_name_1, very_very_long_name_2, very_very_long_name_3],
+    Y = [x1, x2, x3, x4, y1, y2, y3, y4, very_very_long_name_1, very_very_long_name_2| very_very_long_name_3],
+    [X, Y, [x1, x2, x3, x4, y1, y2, y3, y4, very_very_long_name_1, very_very_long_name_2, very_very_long_name_3 | y:z()]].
+
+-spec long_fun() -> fun((X1, X2, X3, X4, Y1, Y2, Y3, Y4, VeryVeryLongName1, VeryVeryLongName2, VeryVeryLongName3) -> {X1, X2, X3, X4, Y1, Y2, Y3, Y4, VeryVeryLongName1, VeryVeryLongName2, VeryVeryLongName3}).
+long_fun() ->
+    fun(X1, X2, X3, X4, Y1, Y2, Y3, Y4, VeryVeryLongName1, VeryVeryLongName2, VeryVeryLongName3) ->
+        {X1, X2, X3, X4, Y1, Y2, Y3, Y4, VeryVeryLongName1, VeryVeryLongName2, VeryVeryLongName3}
+    end.
+
+-spec long_bin() -> binary().
+long_bin() ->
+    X = <<1, 1, 1, 1, 2, 2, 2, 2, 333333333333333333, 333333333333333333, 333333333333333333, 333333333333333333>>,
+    Y = <<1:1, 1:1, 1:1, 1:1, 4:4, 2:2/little-integer-unit:32, 2:2/little-integer-unit:32, 2:2/little-integer-unit:32, 3/float, 3/float, 3/float, 3/float>>,
+    <<X/binary, Y/binary, X/binary, Y/binary, X/binary, Y/binary, X/binary, Y/binary, X/binary, Y/binary>>.
+
+-spec long_guard(integer()) -> integer().
+long_guard(VeryVeryLongName) when is_integer(VeryVeryLongName), VeryVeryLongName < 2, VeryVeryLongName < 3; VeryVeryLongName > 2 andalso VeryVeryLongName > 3 ->
+    if VeryVeryLongName >= -1; VeryVeryLongName < 1, VeryVeryLongName > 0; VeryVeryLongName == 0 -> VeryVeryLongName + 1;
+        VeryVeryLongName -> VeryVeryLongName
+    end.
+
+-spec long_lc() -> [{_, _, _}].
+long_lc() ->
+    [{X, Y, Z} || X <- generator:x(), X < 1, Y <- generator:y(), Z <- generator:z(), filter:x(Y, Z), X + Y == Z].
+
+-spec long_bc() -> binary().
+long_bc() ->
+    << <<X, Y, Z>> || <<X>> <- generator:x(), X < 1, <<Y:2/signed-integer-unit:8>> <- generator:y(), Z <- generator:z(), filter:x(Y, Z), X + Y == Z >>.
+
+-spec long_arglist(number(), number(), number(), float(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> number().
+long_arglist(X1, X2, X3, Y1, VeryVeryLongName1, VeryVeryLongName2, VeryVeryLongName3) ->
+    X1 + X2 + X3 + Y1 + VeryVeryLongName1 + VeryVeryLongName2 + VeryVeryLongName3.
+
+-spec long_rec() -> #long_rec{
+    x1 :: x1,
+    x2 :: x2,
+    x3 :: x3,
+    y1 :: y1,
+    y2 :: y2,
+    y3 :: y3,
+    very_very_long_name_1 :: very_very_long_name_1,
+    very_very_long_name_2 :: very_very_long_name_2,
+    very_very_long_name_3 :: very_very_long_name_3
+}.
+long_rec() -> #long_rec{
+    x1 = x1,
+    x2 = x2,
+    x3 = x3,
+    y1 = y1,
+    y2 = y2,
+    y3 = y3,
+    very_very_long_name_1 = very_very_long_name_1,
+    very_very_long_name_2 = very_very_long_name_2,
+    very_very_long_name_3 = very_very_long_name_3}.
+
+-spec long_map() -> #{
+    x1 := x1,
+    x2 := x2,
+    x3 := x3,
+    y1 := y1,
+    y2 := y2,
+    y3 := y3,
+    very_very_long_name_1 := very_very_long_name_1,
+    very_very_long_name_2 := very_very_long_name_2,
+    very_very_long_name_3 := very_very_long_name_3
+}.
+long_map() -> #{
+    x1 => x1,
+    x2 => x2,
+    x3 => x3,
+    y1 => y1,
+    y2 => y2,
+    y3 => y3,
+    very_very_long_name_1 => very_very_long_name_1,
+    very_very_long_name_2 => very_very_long_name_2,
+    very_very_long_name_3 => very_very_long_name_3}.


### PR DESCRIPTION
I also improved `rebar3_prettypr`'s code a bit.
Feel free to look at `inline_items.erl` and tell me which things should not be considered _lists_ for the purposes of `inline_items`. I just made it affect everything that was possibly concatenated with `,` or `|`.