### PR TITLE
[#30] Add an option to avoid adding empty lines after attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ The plugin supports the following configuration options in the `format` section 
     - This option is only used when `inline_expressions` is `false`.
     - If this option is `true`, one empty line will preserved for each group of empty lines that are placed between expressions in a clause.
     - The default value is `false`.
+* `newline_after_attributes` (`boolean()`):
+    - Specifies if attributes must be separated from the code below them by an empty line.
+    - The default value is `true`.
 
 ### Per-File Configuration
 

--- a/src/rebar3_formatter.erl
+++ b/src/rebar3_formatter.erl
@@ -8,7 +8,8 @@
                   paper => pos_integer(), ribbon => pos_integer(), break_indent => pos_integer(),
                   sub_indent => pos_integer(), remove_tabs => boolean(),
                   remove_trailing_spaces => boolean(), inline_items => boolean(),
-                  inline_expressions => boolean(), preserve_empty_lines => boolean()}.
+                  inline_expressions => boolean(), preserve_empty_lines => boolean(),
+                  newline_after_attributes => boolean()}.
 
 -export_type([opts/0]).
 
@@ -52,6 +53,7 @@ format(File, AST, Comments, Opts) ->
     InlineItems = maps:get(inline_items, Opts, true),
     InlineExpressions = maps:get(inline_expressions, Opts, true),
     PreserveEmptyLines = maps:get(preserve_empty_lines, Opts, false),
+    NewlineAfterAttrs = maps:get(newline_after_attributes, Opts, true),
     FinalFile = case maps:get(output_dir, Opts) of
                   undefined -> File;
                   OutputDir -> filename:join(filename:absname(OutputDir), File)
@@ -59,7 +61,8 @@ format(File, AST, Comments, Opts) ->
     ok = filelib:ensure_dir(FinalFile),
     FormatOpts = [{paper, Paper}, {ribbon, Ribbon}, {encoding, Encoding},
                   {break_indent, BreakIndent}, {sub_indent, SubIndent},
-                  {inline_items, InlineItems}, {inline_expressions, InlineExpressions}],
+                  {inline_items, InlineItems}, {inline_expressions, InlineExpressions},
+                  {newline_after_attributes, NewlineAfterAttrs}],
     ExtendedAST = AST ++ [{eof, 0}],
     WithComments = erl_recomment:recomment_forms(erl_syntax:form_list(ExtendedAST),
                                                  Comments),

--- a/test_app/after/src/newline_after_attributes.erl
+++ b/test_app/after/src/newline_after_attributes.erl
@@ -1,0 +1,32 @@
+-module(newline_after_attributes).
+
+-export([a_fun/0]).
+-export([another_fun/0]).
+
+-format([{newline_after_attributes, false}]).
+
+-dialyzer([{nowarn_function, {a_fun, 0}}]).
+
+-attribute(x).
+-attribute(y).
+
+-type t() :: t(term()).
+-type t(X) :: {X}.
+
+-attribute(z).
+
+-spec a_fun() -> t(boolean()).
+a_fun() -> {true}.
+
+-attribute(w).
+-attribute(w2).
+
+-spec another_fun() -> t(number()).
+another_fun() -> {1}.
+
+-ifdef(LAST).
+
+-attribute(last).
+
+-endif.
+

--- a/test_app/src/newline_after_attributes.erl
+++ b/test_app/src/newline_after_attributes.erl
@@ -1,0 +1,28 @@
+-module(newline_after_attributes).
+
+-export [a_fun/0].
+-export([another_fun/0]).
+
+-format [{newline_after_attributes, false}].
+
+-dialyzer [{nowarn_function, a_fun/0}].
+
+-attribute x.
+-attribute y.
+
+-type t() :: t(term()).
+-type t(X) :: {X}.
+
+-attribute z.
+
+-spec a_fun() -> t(boolean()).
+a_fun() -> {true}.
+
+-attribute w.
+-attribute w2.
+-spec another_fun() -> t(number()).
+another_fun() -> {1}.
+
+-ifdef(LAST).
+-attribute(last).
+-endif.


### PR DESCRIPTION
Not the whole thing, but at least we can now avoid the dreaded empty lines after exports, types and specs.