### PR TITLE
Show line number of unparsable file

### DIFF
--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -123,7 +123,7 @@ format(Files, Formatter, Opts) ->
           end
     catch
       _:{cant_parse, File, {Line, erl_parse, Error}} ->
-          rebar_api:debug("Couldn't parse ~s:~B ~p", [Line, File, Error]),
+          rebar_api:warn("Couldn't parse ~s:~p ~p", [Line, File, Error]),
           {error, {erl_parse, File, Error}};
       _:Error:Stack ->
           rebar_api:warn("Error parsing files: ~p~nStack: ~p", [Error, Stack]),

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -104,8 +104,7 @@ get_opts(State) ->
     proplists:get_value(options, rebar_state:get(State, format, []), #{}).
 
 -spec format([file:filename_all()], module(), rebar3_formatter:opts()) -> ok |
-                                                                          {error,
-                                                                           {atom(), string()}}.
+                                                                          {error, term()}.
 format(Files, Formatter, Opts) ->
     try lists:filter(fun (File) ->
                              rebar_api:debug("Formatting ~p with ~p", [File, Opts]),

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -123,8 +123,8 @@ format(Files, Formatter, Opts) ->
                 {error, {unformatted_files, ChangedFiles}}
           end
     catch
-      _:{cant_parse, File, {_, erl_parse, Error}} ->
-          rebar_api:debug("Couldn't parse ~s: ~p", [File, Error]),
+      _:{cant_parse, File, {Line, erl_parse, Error}} ->
+          rebar_api:debug("Couldn't parse ~s:~B ~p", [Line, File, Error]),
           {error, {erl_parse, File, Error}};
       _:Error:Stack ->
           rebar_api:warn("Error parsing files: ~p~nStack: ~p", [Error, Stack]),


### PR DESCRIPTION
Some times it is hard to find the error in a file. Having the line number would be really neat and helps debugging a lot.