### PR TITLE
Fix #58: Properly dodge and undodge macros on specs and types

### DIFF
--- a/test_app/after/src/dodge_macros.erl
+++ b/test_app/after/src/dodge_macros.erl
@@ -1,0 +1,22 @@
+-module(dodge_macros).
+
+-export([slots/0]).
+
+-define(TOTAL_SLOTS, 10).
+-define(SLOTS_FUN, slots).
+-define(SLOTS_TYPE, slot_id).
+
+-on_load ?SLOTS_FUN/0.
+
+-type ?SLOTS_TYPE() :: other_slot_id().
+-type other_slot_id() :: 1..?TOTAL_SLOTS.
+
+-spec slots() -> ?TOTAL_SLOTS.
+-export_type([?SLOTS_TYPE/0]).
+
+slots() ->
+    ?TOTAL_SLOTS.
+
+-spec slot(?SLOTS_TYPE()) -> {[$?], '?'}.
+slot(?SLOTS_TYPE) ->
+    {"?", '?'}.

--- a/test_app/after/src/type_specs.erl
+++ b/test_app/after/src/type_specs.erl
@@ -73,7 +73,7 @@ b() ->
 
 -define(I, integer).
 
--spec c(Atom :: atom(), Integer :: '?<macro> ('(I)) -> {atom(), integer()};
+-spec c(Atom :: atom(), Integer :: ?I()) -> {atom(), integer()};
        (X, Y) -> {atom(), float()} when X :: atom(), Y :: float();
        (integer(), atom()) -> {integer(), atom()}.
 c(A, B) ->

--- a/test_app/src/dodge_macros.erl
+++ b/test_app/src/dodge_macros.erl
@@ -1,0 +1,22 @@
+-module(dodge_macros).
+
+-export([slots/0]).
+
+-define(TOTAL_SLOTS, 10).
+-define(SLOTS_FUN, slots).
+-define(SLOTS_TYPE, slot_id).
+
+-on_load ?SLOTS_FUN/0.
+
+-type ?SLOTS_TYPE() :: other_slot_id().
+-type other_slot_id() :: 1..?TOTAL_SLOTS.
+
+-spec slots() -> ?TOTAL_SLOTS.
+-export_type([?SLOTS_TYPE/0]).
+
+slots() ->
+    ?TOTAL_SLOTS.
+
+-spec slot(?SLOTS_TYPE()) -> {[$?], '?'}.
+slot(?SLOTS_TYPE) ->
+    {"?", '?'}.


### PR DESCRIPTION
Fix #58: Properly dodge and undodge macros on specs and types