### PR TITLE
[Fix #88] Add inline_attributes as a separate flag to inline_items

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ The plugin supports the following configuration options in the `format` section 
         + `sub_indent`(`pos_integer()`):
             * Specifies the preferred number of characters to use to indent a line that "follows" the current one (for instance, a long clause head or a long function application).
             * The default value is `2`.
+        + `inline_attributes` (`all | none | {when_over, pos_integer()}`):
+            * Specifies the desired behavior for inlining attributes with lists, like `-export`, `-export_type` and `-optional_callbacks`.
+            * When this option is `all`, the formatter will try to fit as many items in each line as permitted by `paper` and `ribbon`.
+            * When the flag is `none`, the formatter will place each item in its own line.
+            * When the flag is `{when_over, N}` the formatter will work as `none` for lists with up to `N` elements, and it will inline longer lists.
+            * The default value is `all`, i.e. always put as many functions/types on each row as possible.
         + `inline_items` (`all | none | {when_over, pos_integer()}`):
             * Specifies the desired behavior when the formatter needs to use multiple lines for a multi-item structure (i.e. tuple, list, map, etc.).
             * **NOTE:** If the formatter can put all items in the same row, it will do it, regardless of this configuration.

--- a/src/otp_formatter.erl
+++ b/src/otp_formatter.erl
@@ -13,21 +13,9 @@
 
 -behaviour(rebar3_formatter).
 
--export([format/1,
-         format/3,
-         best/1,
-         best/2,
-         layout/1,
-         layout/2,
-         get_ctxt_precedence/1,
-         set_ctxt_precedence/2,
-         get_ctxt_paperwidth/1,
-         set_ctxt_paperwidth/2,
-         get_ctxt_linewidth/1,
-         set_ctxt_linewidth/2,
-         get_ctxt_hook/1,
-         set_ctxt_hook/2,
-         get_ctxt_user/1,
+-export([format/1, format/3, best/1, best/2, layout/1, layout/2, get_ctxt_precedence/1,
+         set_ctxt_precedence/2, get_ctxt_paperwidth/1, set_ctxt_paperwidth/2, get_ctxt_linewidth/1,
+         set_ctxt_linewidth/2, get_ctxt_hook/1, set_ctxt_hook/2, get_ctxt_user/1,
          set_ctxt_user/2]).
 
 -import(prettypr,

--- a/test_app/after/src/inline_attributes.erl
+++ b/test_app/after/src/inline_attributes.erl
@@ -1,0 +1,45 @@
+-module(inline_attributes).
+
+-format #{inline_attributes => all}.
+
+-export([these/0, functions/0, should/0, be/0, inlined/0]).
+
+-callback these() -> {elements, should, be, inlined}.
+-callback functions() -> #{should => be, inlined => too}.
+-callback should() -> should.
+-callback be() -> ok.
+-callback inlined(even, If, they, have, arguments) -> If.
+-callback too() -> too.
+
+-optional_callbacks([these/0, functions/0, should/0, be/0, inlined/5, too/0]).
+
+-type these() :: {types, should, be, inlined, as, well}.
+-type types() :: [all | 'of' | them].
+-type should() :: should.
+-type be() :: be.
+-type inlined() :: inlined.
+-type too() :: too.
+
+-export_type([these/0, types/0, should/0, be/0, inlined/0, too/0]).
+
+-type the_attributes(Of, This, Type) :: #{should => Of, be => This, inlined => Type}.
+
+-record(the_fields, {'of', this, record, should, be, inlined, too}).
+
+these() ->
+    ok.
+
+functions() ->
+    ok.
+
+should() ->
+    ok.
+
+be() ->
+    ok.
+
+inlined() ->
+    ok.
+
+too() ->
+    ok.

--- a/test_app/after/src/inline_items.erl
+++ b/test_app/after/src/inline_items.erl
@@ -22,16 +22,8 @@
 -export([short_bin/0, short_guard/1, short_lc/0]).
 -export([short_bc/0, short_arglist/3, short_rec/0]).
 -export([short_map/0]).
--export([long_tuple/0,
-         long_list/0,
-         long_fun/0,
-         long_bin/0,
-         long_guard/1,
-         long_lc/0,
-         long_bc/0,
-         long_arglist/7,
-         long_rec/0,
-         long_map/0]).
+-export([long_tuple/0, long_list/0, long_fun/0, long_bin/0, long_guard/1,
+         long_lc/0, long_bc/0, long_arglist/7, long_rec/0, long_map/0]).
 -export([short/0, exact/0, long/0]).
 
 -spec short_tuple() -> {T, T, T} when T :: {x, y, z}.

--- a/test_app/after/src/not_inline_attributes.erl
+++ b/test_app/after/src/not_inline_attributes.erl
@@ -1,0 +1,59 @@
+-module(not_inline_attributes).
+
+-format #{inline_attributes => none}.
+
+-export([these/0,
+         functions/0,
+         shouldnt/0,
+         be/0,
+         inlined/0]).
+
+-callback these() -> {elements, should, be, inlined}.
+-callback functions() -> #{should => be, inlined => {as, well}}.
+-callback shouldnt() -> should.
+-callback be() -> ok.
+-callback inlined(even, If, they, have, arguments) -> If.
+-callback either() -> either.
+
+-optional_callbacks([these/0,
+                     functions/0,
+                     shouldnt/0,
+                     be/0,
+                     inlined/5,
+                     either/0]).
+
+-type these() :: {types, shouldnt, be, inlined, as, well}.
+-type types() :: [all | 'of' | them].
+-type shouldnt() :: shouldnt.
+-type be() :: be.
+-type inlined() :: inlined.
+-type either() :: either.
+
+-export_type([these/0,
+              types/0,
+              shouldnt/0,
+              be/0,
+              inlined/0,
+              either/0]).
+
+-type the_attributes(Of, This, Type) :: #{should => Of, be => This, inlined => Type}.
+
+-record(the_fields, {'of', this, record, should, be, inlined, too}).
+
+these() ->
+    ok.
+
+functions() ->
+    ok.
+
+shouldnt() ->
+    ok.
+
+be() ->
+    ok.
+
+inlined() ->
+    ok.
+
+either() ->
+    ok.

--- a/test_app/after/src/syntax_tools_SUITE_test_module.erl
+++ b/test_app/after/src/syntax_tools_SUITE_test_module.erl
@@ -1,36 +1,10 @@
 -module(syntax_tools_SUITE_test_module).
 
 -export([foo1/1, foo2/3, start_child/2]).
--export([len/1,
-         equal/2,
-         concat/2,
-         chr/2,
-         rchr/2,
-         str/2,
-         rstr/2,
-         span/2,
-         cspan/2,
-         substr/2,
-         substr/3,
-         tokens/2,
-         chars/2,
-         chars/3]).
--export([copies/2,
-         words/1,
-         words/2,
-         strip/1,
-         strip/2,
-         strip/3,
-         sub_word/2,
-         sub_word/3,
-         left/2,
-         left/3,
-         right/2,
-         right/3,
-         sub_string/2,
-         sub_string/3,
-         centre/2,
-         centre/3,
+-export([len/1, equal/2, concat/2, chr/2, rchr/2, str/2, rstr/2, span/2, cspan/2,
+         substr/2, substr/3, tokens/2, chars/2, chars/3]).
+-export([copies/2, words/1, words/2, strip/1, strip/2, strip/3, sub_word/2, sub_word/3,
+         left/2, left/3, right/2, right/3, sub_string/2, sub_string/3, centre/2, centre/3,
          join/2]).
 -export([to_upper/1, to_lower/1]).
 

--- a/test_app/src/inline_attributes.erl
+++ b/test_app/src/inline_attributes.erl
@@ -1,0 +1,34 @@
+-module(inline_attributes).
+
+-format #{inline_attributes => all}.
+
+-export [these/0, functions/0, should/0, be/0, inlined/0].
+
+-callback these() -> {elements, should, be, inlined}.
+-callback functions() -> #{should => be, inlined => too}.
+-callback should() -> should.
+-callback be() -> ok.
+-callback inlined(even, If, they, have, arguments) -> If.
+-callback too() -> too.
+
+-optional_callbacks [these/0, functions/0, should/0, be/0, inlined/5, too/0].
+
+-type these() :: {types, should, be, inlined, as, well}.
+-type types() :: [all | 'of' | them].
+-type should() :: should.
+-type be() :: be.
+-type inlined() :: inlined.
+-type too() :: too.
+
+-export_type [these/0, types/0, should/0, be/0, inlined/0, too/0].
+
+-type the_attributes(Of, This, Type) :: #{should => Of, be => This, inlined => Type}.
+
+-record(the_fields, {'of', this, record, should, be, inlined, too}).
+
+these() -> ok.
+functions() -> ok.
+should() -> ok.
+be() -> ok.
+inlined() -> ok.
+too() -> ok.

--- a/test_app/src/not_inline_attributes.erl
+++ b/test_app/src/not_inline_attributes.erl
@@ -1,0 +1,34 @@
+-module(not_inline_attributes).
+
+-format #{inline_attributes => none}.
+
+-export [these/0, functions/0, shouldnt/0, be/0, inlined/0].
+
+-callback these() -> {elements, should, be, inlined}.
+-callback functions() -> #{should => be, inlined => {as, well}}.
+-callback shouldnt() -> should.
+-callback be() -> ok.
+-callback inlined(even, If, they, have, arguments) -> If.
+-callback either() -> either.
+
+-optional_callbacks [these/0, functions/0, shouldnt/0, be/0, inlined/5, either/0].
+
+-type these() :: {types, shouldnt, be, inlined, as, well}.
+-type types() :: [all | 'of' | them].
+-type shouldnt() :: shouldnt.
+-type be() :: be.
+-type inlined() :: inlined.
+-type either() :: either.
+
+-export_type [these/0, types/0, shouldnt/0, be/0, inlined/0, either/0].
+
+-type the_attributes(Of, This, Type) :: #{should => Of, be => This, inlined => Type}.
+
+-record(the_fields, {'of', this, record, should, be, inlined, too}).
+
+these() -> ok.
+functions() -> ok.
+shouldnt() -> ok.
+be() -> ok.
+inlined() -> ok.
+either() -> ok.


### PR DESCRIPTION
Fixes #88 by adding `inline_attributes` with default `all`.