### PR TITLE
[#110] Allow users to use erlfmt from within rebar3 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ That way each developer can read code in the way they understand it better, writ
 Through `rebar3 format`, you can use other formatters that are not included in this repository. That way you can follow our proposed workflow and allow each developer to format the code with their favorite formatter using rebar3 plugins while still maintaining an unique _canonical formatter_ when pushing to your central git repository.
 You also get `-format` attribute compliance (including `-format ignore.`) for free, since they're respected when using any formatter.
 
+### erlfmt
+If you want to use @whatsapp's [erlfmt](https://github.com/whatsapp/erlfmt), you just need to add the following things to your `rebar.config` file:
+
+```erlang
+{plugins, [rebar3_format, erlfmt]}.
+{format, [
+    {files, ["src/*.erl", "include/*.hrl"]},
+    {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]},
+    {formatter, erlfmt_formatter} %% The erlfmt formatter interface.
+]}.
+```
+
+#### Compatibility Note
+`erlfmt_formatter` is compatible with version `v0.1.0` of `erlfmt`, which is the only one that's currently available at [hex.pm](https://hex.pm/packages/erlfmt). When a new version is published, we'll need to adjust our code since the API for `erlfmt` will change (it already changed in their `master` branch).
+
 ## Implementing your own Formatter
 
 To create a new formatter, you need to implement the `rebar3_formatter` behaviour. It defines just one callback:

--- a/src/formatters/erlfmt_formatter.erl
+++ b/src/formatters/erlfmt_formatter.erl
@@ -1,0 +1,48 @@
+%%% @doc Formatter to integrate with
+%%%      <a target="_blank" href="https://github.com/whatsapp/erlfmt">erlfmt</a>.
+-module(erlfmt_formatter).
+
+-behaviour(rebar3_formatter).
+
+-export([format/2]).
+
+%% @doc Format a file.
+%%      Apply formatting rules to a file containing erlang code.
+%%      Use <code>Opts</code> to configure the formatter.
+-spec format(file:filename_all(), rebar3_formatter:opts()) -> rebar3_formatter:result().
+format(File, OptionsMap) ->
+    {ok, _} = application:ensure_all_started(erlfmt),
+    Out = case maps:get(output_dir, OptionsMap, current) of
+            current -> %% Action can only be 'format'
+                replace;
+            none ->
+                %% Action can only be 'verify'
+                %% We need to dump the output somewhere since erlfmt has no
+                %% concept of verify / check / etc.
+                filename:join("/tmp", File);
+            OutputDir ->
+                filename:join(filename:absname(OutputDir), File)
+          end,
+    OutFile = case Out of
+                replace ->
+                    File;
+                Out ->
+                    Out
+              end,
+
+    {ok, Code} = file:read_file(File),
+
+    try erlfmt:format_file(File, Out) of
+      {ok, _} ->
+          case file:read_file(OutFile) of
+            {ok, Code} ->
+                unchanged;
+            {ok, _} ->
+                changed
+          end;
+      {error, Reason} ->
+          erlang:error(Reason)
+    catch
+      _:{error, Reason} ->
+          erlang:error(Reason)
+    end.

--- a/test/erlfmt.app
+++ b/test/erlfmt.app
@@ -1,0 +1,8 @@
+{
+    application,
+    erlfmt,
+    [
+        {description,"An app file to get erlfmt_formatter_SUITE to run nicely"},
+        {applications,[kernel,stdlib]}
+    ]
+}.

--- a/test/erlfmt.erl
+++ b/test/erlfmt.erl
@@ -1,0 +1,21 @@
+%%% @doc This module is only used for tests to simulate the actual erlfmt
+-module(erlfmt).
+
+-export([format_file/2, validator/1]).
+
+-type error_info() :: {file:name_all(), erl_anno:location(), module(), Reason :: any()}.
+-type out() :: standard_out | {path, file:name_all()} | replace.
+
+-spec validator(fun((file:name_all(), out()) -> {ok, [error_info()]} |
+                                                {error, error_info()})) -> ok.
+validator(Fun) ->
+    application:set_env(rebar3_format, erlfmt_formatter_validator, Fun).
+
+-spec format_file(file:name_all(), out()) -> {ok, [error_info()]} | {error, error_info()}.
+format_file(File, Opts) ->
+    Validator = application:get_env(rebar3_format,
+                                    erlfmt_formatter_validator,
+                                    fun (_, _) ->
+                                            ok
+                                    end),
+    Validator(File, Opts).

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -1,0 +1,63 @@
+-module(erlfmt_formatter_SUITE).
+
+-export([all/0]).
+-export([action/1, output_dir/1]).
+
+all() ->
+    [action, output_dir].
+
+action(_Config) ->
+    erlfmt:validator(fun (File, Out) ->
+                             "brackets.erl" = filename:basename(File),
+                             "/tmp/src/brackets.erl" = Out,
+                             copy_file(File, Out),
+                             {ok, []}
+                     end),
+    Args1 = rebar_state:command_parsed_args(init(), {[{verify, true}], something}),
+    {ok, _} = rebar3_format_prv:do(Args1),
+
+    erlfmt:validator(fun (File, Out) ->
+                             "brackets.erl" = filename:basename(File),
+                             replace = Out,
+                             {ok, []}
+                     end),
+    Args2 = rebar_state:command_parsed_args(init(), {[], something}),
+    {ok, _} = rebar3_format_prv:do(Args2),
+
+    erlfmt:validator(fun (_, Out) ->
+                             file:write_file(Out, "something different"),
+                             {ok, []}
+                     end),
+    {error, _} = rebar3_format_prv:do(Args1).
+
+output_dir(_Config) ->
+    % When there is no expected output, erlfmt's out should be 'replace'
+    erlfmt:validator(fun (File, Out) ->
+                             "src/brackets.erl" = File,
+                             replace = Out,
+                             {ok, []}
+                     end),
+    Args1 = rebar_state:command_parsed_args(init(), {[], something}),
+    {ok, _} = rebar3_format_prv:do(Args1),
+
+    % When there is an expected output, erlfmt's out should be it
+    erlfmt:validator(fun (File, Out) ->
+                             "brackets.erl" = filename:basename(File),
+                             "/tmp/src/brackets.erl" = Out,
+                             {ok, []}
+                     end),
+    Args2 = rebar_state:command_parsed_args(init(), {[{output, "/tmp/"}], something}),
+    {ok, _} = rebar3_format_prv:do(Args2).
+
+init() ->
+    ok = file:set_cwd(filename:join(code:priv_dir(rebar3_format), "../test_app")),
+    {ok, State1} = rebar3_format:init(rebar_state:new()),
+    Files = {files, ["src/brackets.erl"]},
+    Formatter = {formatter, erlfmt_formatter},
+    Out = {options, #{}},
+    rebar_state:set(State1, format, [Files, Formatter, Out]).
+
+copy_file(File, OutFile) ->
+    ok = filelib:ensure_dir(OutFile),
+    {ok, _} = file:copy(File, OutFile),
+    ok.


### PR DESCRIPTION
Part of #110. Just like #112, but for WhatsApp's `erlfmt`.