### PR TITLE
[Fix #56] Handle quoted atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The plugin supports the following configuration options in the `format` section 
         + `sub_indent`(`pos_integer()`):
             * Specifies the preferred number of characters to use to indent a line that "follows" the current one (for instance, a long clause head or a long function application).
             * The default value is `2`.
+        + `unquote_atoms` (`boolean()`):
+            * Specifies whether the formatter should remove quotes from atoms that don't need them (e.g. `'this_one'`) or not.
+            * The default value is `true`, i.e. the formatter won't preserve your quotes if they're not needed, unless you explicitely ask for.
         + `inline_attributes` (`all | none | {when_over, pos_integer()}`):
             * Specifies the desired behavior for inlining attributes with lists, like `-export`, `-export_type` and `-optional_callbacks`.
             * When this option is `all`, the formatter will try to fit as many items in each line as permitted by `paper` and `ribbon`.

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -60,6 +60,7 @@
          force_inlining = false :: boolean(),
          inline_clause_bodies = false :: boolean(),
          inline_expressions = false :: boolean(),
+         unquote_atoms = true :: boolean(),
          empty_lines = [] :: [pos_integer()],
          encoding = epp:default_encoding() :: epp:source_encoding()}).
 
@@ -141,6 +142,7 @@ layout(Node, EmptyLines, Options) ->
               inline_expressions = maps:get(inline_expressions, Options, false),
               inline_items = maps:get(inline_items, Options, {when_over, 25}),
               inline_attributes = maps:get(inline_attributes, Options, all),
+              unquote_atoms = maps:get(unquote_atoms, Options, true),
               empty_lines = EmptyLines,
               encoding = maps:get(encoding, Options, epp:default_encoding())}).
 
@@ -212,7 +214,7 @@ lay_no_comments(Node, Ctxt) ->
       variable ->
           text(erl_syntax:variable_literal(Node));
       atom ->
-          text(erl_syntax:atom_literal(Node, Ctxt#ctxt.encoding));
+          text(tidy_atom(Node, Ctxt));
       integer ->
           text(tidy_integer(Node));
       float ->
@@ -1101,6 +1103,21 @@ tidy_char(Node, Encoding) ->
           erl_syntax:char_literal(Node, Encoding);
       Text ->
           Text
+    end.
+
+tidy_atom(Node, #ctxt{encoding = Encoding, unquote_atoms = true}) ->
+    erl_syntax:atom_literal(Node, Encoding);
+tidy_atom(Node, #ctxt{encoding = Encoding}) ->
+    case erl_syntax:is_tree(Node) of
+      true -> %% It's not exactly an atom (e.g. module, export, spec)
+          erl_syntax:atom_literal(Node, Encoding);
+      false ->
+          case get_node_text(Node) of
+            undefined ->
+                erl_syntax:atom_literal(Node, Encoding);
+            Text ->
+                Text
+          end
     end.
 
 %% @doc If we captured the original text for the number, then we use it.

--- a/test_app/after/src/quoted_atoms.erl
+++ b/test_app/after/src/quoted_atoms.erl
@@ -1,0 +1,23 @@
+%% Module names can't be _forcefully_ quoted
+-module(quoted_atoms).
+
+-format #{unquote_atoms => false}.
+
+%% Function names can't be _forcefully_ quoted, either
+%% But if the quotes are "required", they stay.
+-export([qf/1, 'QF'/1]).
+
+%% Type names can't be _forcefully_ quoted, either
+-type qt() :: 'qp'.
+%% But if the quotes are "required", they stay.
+-type 'QT'() :: 'QT'.
+
+-export_type([qt/0, 'QT'/0]).
+
+-spec qf('qp') -> 'qr'.
+qf('qp') ->
+    'qr'.
+
+-spec 'QF'(qt()) -> qr.
+'QF'(qp) ->
+    qr.

--- a/test_app/after/src/unquoted_atoms.erl
+++ b/test_app/after/src/unquoted_atoms.erl
@@ -1,0 +1,18 @@
+-module(unquoted_atoms).
+
+-format #{unquote_atoms => true}.
+
+-export([qf/1, 'QF'/1]).
+
+-type qt() :: qp.
+-type 'QT'() :: 'QT'.
+
+-export_type([qt/0, 'QT'/0]).
+
+-spec qf(qp) -> qr.
+qf(qp) ->
+    qr.
+
+-spec 'QF'(qt()) -> qr.
+'QF'(qp) ->
+    qr.

--- a/test_app/src/quoted_atoms.erl
+++ b/test_app/src/quoted_atoms.erl
@@ -1,0 +1,22 @@
+%% Module names can't be _forcefully_ quoted
+-module('quoted_atoms').
+
+-format #{unquote_atoms => false}.
+
+%% Function names can't be _forcefully_ quoted, either
+%% But if the quotes are "required", they stay.
+-export(['qf'/1, 'QF'/1]).
+
+%% Type names can't be _forcefully_ quoted, either
+-type 'qt'() :: 'qp'.
+%% But if the quotes are "required", they stay.
+-type 'QT'() :: 'QT'.
+
+-export_type ['qt'/0, 'QT'/0].
+
+-spec 'qf'('qp') -> 'qr'.
+'qf'('qp') ->
+    'qr'.
+
+-spec 'QF'('qt'()) -> qr.
+'QF'(qp) -> qr.

--- a/test_app/src/unquoted_atoms.erl
+++ b/test_app/src/unquoted_atoms.erl
@@ -1,0 +1,17 @@
+-module('unquoted_atoms').
+
+-format #{unquote_atoms => true}.
+
+-export(['qf'/1, 'QF'/1]).
+
+-type 'qt'() :: 'qp'.
+-type 'QT'() :: 'QT'.
+
+-export_type ['qt'/0, 'QT'/0].
+
+-spec 'qf'('qp') -> 'qr'.
+'qf'('qp') ->
+    'qr'.
+
+-spec 'QF'('qt'()) -> qr.
+'QF'(qp) -> qr.


### PR DESCRIPTION
Add new option (`unquote_atoms`) with default `true`, to preserve atom quoting.