### PR TITLE
[#55] Some initial steps

### DIFF
--- a/test_app/after/src/strings.erl
+++ b/test_app/after/src/strings.erl
@@ -5,7 +5,7 @@
 -format #{inline_expressions => true}.
 
 all() ->
-    heredoc(), superlong(), repeat(), multiple_calls().
+    heredoc(), superlong(), repeat(), multiple_calls(), characters().
 
 superlong() ->
     "This is a super super super super super super super super super "
@@ -49,3 +49,7 @@ multiple_calls_more() ->
     repeat(),
     repeat(),
     repeat().
+
+characters() ->
+    {"\x63haracters with strange representations are preserved" ++ " in small strings",
+     "but they're not preserved in multiblock strings"}.

--- a/test_app/src/strings.erl
+++ b/test_app/src/strings.erl
@@ -8,7 +8,8 @@ all() ->
   heredoc(),
   superlong(),
   repeat(),
-  multiple_calls().
+  multiple_calls(),
+  characters().
 
 
 superlong() ->
@@ -48,3 +49,11 @@ multiple_calls_more() ->
   repeat(),
   repeat(),
   repeat().
+
+characters() ->
+    {
+    "\x63haracters with strange representations are preserved"
+    ++ " in small strings",
+    "\x62ut they're not"
+    " preserved in multiblock strings"
+    }.


### PR DESCRIPTION
We still can't handle multi-block strings, so the "implicit" concatenation thing will still happen, but at least now `\x61` will not be turned into `a`.