### PR TITLE
[Fix #90] Indent specs on ->

### DIFF
--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -76,9 +76,8 @@ reset_prec(Ctxt) ->
 %% @see erl_syntax
 %% @see format/1
 %% @see layout/2
--spec format(erl_syntax:syntaxTree(),
-             [pos_integer()],
-             rebar3_formatter:opts()) -> string().
+-spec format(erl_syntax:syntaxTree(), [pos_integer()], rebar3_formatter:opts()) ->
+                string().
 format(Node, EmptyLines, Options) ->
     W = maps:get(paper, Options, ?PAPER),
     L = maps:get(ribbon, Options, ?RIBBON),
@@ -102,9 +101,8 @@ init(_, _) ->
 %% @doc Format a file.
 %%      Apply formatting rules to a file containing erlang code.
 %%      Use <code>Opts</code> to configure the formatter.
--spec format_file(file:filename_all(),
-                  nostate,
-                  rebar3_formatter:opts()) -> rebar3_formatter:result().
+-spec format_file(file:filename_all(), nostate, rebar3_formatter:opts()) ->
+                     rebar3_formatter:result().
 format_file(File, nostate, Opts) ->
     rebar3_ast_formatter:format(File, ?MODULE, Opts).
 
@@ -129,9 +127,8 @@ remove_trailing_spaces(Formatted) ->
 %%
 %% @see prettypr
 %% @see format/2
--spec layout(erl_syntax:syntaxTree(),
-             [pos_integer()],
-             rebar3_formatter:opts()) -> prettypr:document().
+-spec layout(erl_syntax:syntaxTree(), [pos_integer()], rebar3_formatter:opts()) ->
+                prettypr:document().
 layout(Node, EmptyLines, Options) ->
     lay(Node,
         #ctxt{paper = maps:get(paper, Options, ?PAPER),
@@ -697,7 +694,8 @@ lay_no_comments(Node, Ctxt) ->
                end,
           D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
           beside(lay_text_float(Before),
-                 beside(D1, beside(lay_text_float(" -> "), beside(D2, lay_text_float(After)))));
+                 sep([beside(D1, lay_text_float(" ->")),
+                      nest(Ctxt#ctxt.break_indent, beside(D2, lay_text_float(After)))]));
       constraint ->
           Name = erl_syntax:constraint_argument(Node),
           Args = erl_syntax:constraint_body(Node),

--- a/src/formatters/erlfmt_formatter.erl
+++ b/src/formatters/erlfmt_formatter.erl
@@ -16,9 +16,8 @@ init(_, _) ->
 %% @doc Format a file.
 %%      Note that opts() are not the same as the global ones passed in on init/1.
 %%      These opts include per-file options specified with the -format attribute.
--spec format_file(file:filename_all(),
-                  nostate,
-                  rebar3_formatter:opts()) -> rebar3_formatter:result().
+-spec format_file(file:filename_all(), nostate, rebar3_formatter:opts()) ->
+                     rebar3_formatter:result().
 format_file(File, nostate, OptionsMap) ->
     Out = case maps:get(output_dir, OptionsMap, current) of
             current -> %% Action can only be 'format'

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -178,9 +178,8 @@ init(_, _) -> nostate.
 %% @doc Format a file.
 %%      Apply formatting rules to a file containing erlang code.
 %%      Use <code>Opts</code> to configure the formatter.
--spec format_file(file:filename_all(),
-                  nostate,
-                  rebar3_formatter:opts()) -> rebar3_formatter:result().
+-spec format_file(file:filename_all(), nostate, rebar3_formatter:opts()) ->
+                     rebar3_formatter:result().
 format_file(File, nostate, Opts) -> rebar3_ast_formatter:format(File, ?MODULE, Opts).
 
 %% =====================================================================
@@ -271,9 +270,8 @@ format(Node) -> format(Node, [], #{}).
 %% @see get_ctxt_user/1
 %% @see set_ctxt_user/2
 
--spec format(erl_syntax:syntaxTree(),
-             [pos_integer()],
-             rebar3_formatter:opts()) -> string().
+-spec format(erl_syntax:syntaxTree(), [pos_integer()], rebar3_formatter:opts()) ->
+                string().
 format(Node, _EmptyLines, Options) ->
     W = maps:get(paper, Options, ?PAPER),
     L = maps:get(ribbon, Options, ?RIBBON),

--- a/src/formatters/sr_formatter.erl
+++ b/src/formatters/sr_formatter.erl
@@ -23,9 +23,8 @@ init(Opts, RebarState) ->
 %% @doc Format a file.
 %%      Note that opts() are not the same as the global ones passed in on init/1.
 %%      These opts include per-file options specified with the -format attribute.
--spec format_file(file:filename_all(),
-                  state(),
-                  rebar3_formatter:opts()) -> rebar3_formatter:result().
+-spec format_file(file:filename_all(), state(), rebar3_formatter:opts()) ->
+                     rebar3_formatter:result().
 format_file(File, #{opts := GlobalOpts}, OptionsMap) ->
     %% NOTE: This works because we know that...
     %%       1. Opts are treated as a proplist in steamroller

--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -3,16 +3,14 @@
 
 -export([format/3]).
 
--callback format(erl_syntax:forms(),
-                 [pos_integer()],
-                 rebar3_formatter:opts()) -> string().
+-callback format(erl_syntax:forms(), [pos_integer()], rebar3_formatter:opts()) ->
+                    string().
 
 %% @doc Format a file.
 %%      Apply formatting rules to a file containing erlang code.
 %%      Use <code>Opts</code> to configure the formatter.
--spec format(file:filename_all(),
-             module(),
-             rebar3_formatter:opts()) -> rebar3_formatter:result().
+-spec format(file:filename_all(), module(), rebar3_formatter:opts()) ->
+                rebar3_formatter:result().
 format(File, Formatter, Opts) ->
     AST = get_ast(File),
     QuickAST = get_quick_ast(File),

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -90,9 +90,8 @@ get_ignored_files(State) ->
     Patterns = proplists:get_value(ignore, FormatConfig, []),
     [IgnoredFile || Pat <- Patterns, IgnoredFile <- filelib:wildcard(Pat)].
 
--spec get_output_dir(format | verify, proplists:proplist()) -> none |
-                                                               current |
-                                                               file:filename_all().
+-spec get_output_dir(format | verify, proplists:proplist()) ->
+                        none | current | file:filename_all().
 get_output_dir(Action, Args) ->
     case {lists:keyfind(output, 1, Args), Action} of
       {{output, OutputDir}, _} ->

--- a/test/erlfmt.erl
+++ b/test/erlfmt.erl
@@ -6,8 +6,9 @@
 -type error_info() :: {file:name_all(), erl_anno:location(), module(), Reason :: any()}.
 -type out() :: standard_out | {path, file:name_all()} | replace.
 
--spec validator(fun((file:name_all(), out()) -> {ok, [error_info()]} |
-                                                {error, error_info()})) -> ok.
+-spec validator(fun((file:name_all(), out()) ->
+                        {ok, [error_info()]} | {error, error_info()})) ->
+                   ok.
 validator(Fun) ->
     application:set_env(rebar3_format, erlfmt_formatter_validator, Fun).
 

--- a/test_app/after/src/indent_18.erl
+++ b/test_app/after/src/indent_18.erl
@@ -52,8 +52,8 @@ if_expr() ->
 -type
   a_type_with_a_very_long_name() :: this_type:definition_doesnt_fit_in(a:line()).
 
--spec
-  a_function_with_a_very_long_name() -> a_type_with_a_very_long_name().
+-spec a_function_with_a_very_long_name() ->
+                                       a_type_with_a_very_long_name().
 a_function_with_a_very_long_name() ->
  {specs,
   " and ",

--- a/test_app/after/src/indent_81.erl
+++ b/test_app/after/src/indent_81.erl
@@ -54,8 +54,8 @@ if_expr() ->
 -type
          a_type_with_a_very_long_name() :: this_type:definition_doesnt_fit_in(a:line()).
 
--spec
-         a_function_with_a_very_long_name() -> a_type_with_a_very_long_name().
+-spec a_function_with_a_very_long_name() ->
+                                              a_type_with_a_very_long_name().
 a_function_with_a_very_long_name() ->
         {specs,
          " and ",

--- a/test_app/after/src/inline_clause_bodies.erl
+++ b/test_app/after/src/inline_clause_bodies.erl
@@ -5,22 +5,12 @@
 -compile(export_all).
 
 -callback f(inline, this, clause, _) -> [just | like];
-           (inline,
-            this,
-            other,
-            much_much_larger_clause) -> [please |
-                                         mister |
-                                         rebar3 |
-                                         formatter].
+           (inline, this, other, much_much_larger_clause) ->
+               [please | mister | rebar3 | formatter].
 
 -spec f_cs(inline, this, clause, _) -> [just | like];
-          (inline,
-           this,
-           other,
-           much_much_larger_clause) -> [please |
-                                        mister |
-                                        rebar3 |
-                                        formatter].
+          (inline, this, other, much_much_larger_clause) ->
+              [please | mister | rebar3 | formatter].
 f_cs(inline, this, clause, _) ->
     [just, like];
 f_cs(inline, this, other, much_much_larger_clause) ->

--- a/test_app/after/src/inline_items.erl
+++ b/test_app/after/src/inline_items.erl
@@ -166,27 +166,29 @@ long_list() ->
       very_very_long_name_3
       | y:z()]].
 
--spec long_fun() -> fun((X1,
-                         X2,
-                         X3,
-                         X4,
-                         Y1,
-                         Y2,
-                         Y3,
-                         Y4,
-                         VeryVeryLongName1,
-                         VeryVeryLongName2,
-                         VeryVeryLongName3) -> {X1,
-                                                X2,
-                                                X3,
-                                                X4,
-                                                Y1,
-                                                Y2,
-                                                Y3,
-                                                Y4,
-                                                VeryVeryLongName1,
-                                                VeryVeryLongName2,
-                                                VeryVeryLongName3}).
+-spec long_fun() ->
+                  fun((X1,
+                       X2,
+                       X3,
+                       X4,
+                       Y1,
+                       Y2,
+                       Y3,
+                       Y4,
+                       VeryVeryLongName1,
+                       VeryVeryLongName2,
+                       VeryVeryLongName3) ->
+                          {X1,
+                           X2,
+                           X3,
+                           X4,
+                           Y1,
+                           Y2,
+                           Y3,
+                           Y4,
+                           VeryVeryLongName1,
+                           VeryVeryLongName2,
+                           VeryVeryLongName3}).
 long_fun() ->
     fun (X1,
          X2,
@@ -289,7 +291,8 @@ long_bc() ->
                    float(),
                    non_neg_integer(),
                    non_neg_integer(),
-                   non_neg_integer()) -> number().
+                   non_neg_integer()) ->
+                      number().
 long_arglist(X1,
              X2,
              X3,
@@ -300,15 +303,16 @@ long_arglist(X1,
     X1 + X2 + X3 + Y1 + VeryVeryLongName1 + VeryVeryLongName2 +
       VeryVeryLongName3.
 
--spec long_rec() -> #long_rec{x1 :: x1,
-                              x2 :: x2,
-                              x3 :: x3,
-                              y1 :: y1,
-                              y2 :: y2,
-                              y3 :: y3,
-                              very_very_long_name_1 :: very_very_long_name_1,
-                              very_very_long_name_2 :: very_very_long_name_2,
-                              very_very_long_name_3 :: very_very_long_name_3}.
+-spec long_rec() ->
+                  #long_rec{x1 :: x1,
+                            x2 :: x2,
+                            x3 :: x3,
+                            y1 :: y1,
+                            y2 :: y2,
+                            y3 :: y3,
+                            very_very_long_name_1 :: very_very_long_name_1,
+                            very_very_long_name_2 :: very_very_long_name_2,
+                            very_very_long_name_3 :: very_very_long_name_3}.
 long_rec() ->
     #long_rec{x1 = x1,
               x2 = x2,
@@ -320,15 +324,16 @@ long_rec() ->
               very_very_long_name_2 = very_very_long_name_2,
               very_very_long_name_3 = very_very_long_name_3}.
 
--spec long_map() -> #{x1 := x1,
-                      x2 := x2,
-                      x3 := x3,
-                      y1 := y1,
-                      y2 := y2,
-                      y3 := y3,
-                      very_very_long_name_1 := very_very_long_name_1,
-                      very_very_long_name_2 := very_very_long_name_2,
-                      very_very_long_name_3 := very_very_long_name_3}.
+-spec long_map() ->
+                  #{x1 := x1,
+                    x2 := x2,
+                    x3 := x3,
+                    y1 := y1,
+                    y2 := y2,
+                    y3 := y3,
+                    very_very_long_name_1 := very_very_long_name_1,
+                    very_very_long_name_2 := very_very_long_name_2,
+                    very_very_long_name_3 := very_very_long_name_3}.
 long_map() ->
     #{x1 => x1,
       x2 => x2,

--- a/test_app/after/src/syntax_tools_SUITE_test_module.erl
+++ b/test_app/after/src/syntax_tools_SUITE_test_module.erl
@@ -27,7 +27,8 @@ foo1(#{a := 1, b := V}) ->
 
 -spec foo2(Type1 :: some_type(),
            Type2 :: some_other_type(),
-           Map :: #{get => value, value => binary()}) -> binary().
+           Map :: #{get => value, value => binary()}) ->
+              binary().
 foo2(Type1, {a, #{"a" := _}}, #{get := value, value := B}) when is_map(Type1) ->
     B.
 


### PR DESCRIPTION
Fixes #90 by indenting long specs on `->`. The alternative of turning them into constrained specs (i.e. with `when`) was impossible to get right since the formatter would've had to come up with "sensible" variable names for the types.