### PR TITLE
[Fix #75] Indent long lines on =

### DIFF
--- a/src/formatters/erlfmt_formatter.erl
+++ b/src/formatters/erlfmt_formatter.erl
@@ -20,32 +20,35 @@ init(_, _) ->
                   nostate,
                   rebar3_formatter:opts()) -> rebar3_formatter:result().
 format_file(File, nostate, OptionsMap) ->
-    Out = case maps:get(output_dir, OptionsMap, current) of
-            current -> %% Action can only be 'format'
-                replace;
-            none ->
-                %% Action can only be 'verify'
-                %% We need to dump the output somewhere since erlfmt has no
-                %% concept of verify / check / etc.
-                filename:join("/tmp", File);
-            OutputDir ->
-                filename:join(filename:absname(OutputDir), File)
-          end,
-    OutFile = case Out of
-                replace ->
-                    File;
-                Out ->
-                    Out
-              end,
+    Out =
+        case maps:get(output_dir, OptionsMap, current) of
+          current -> %% Action can only be 'format'
+              replace;
+          none ->
+              %% Action can only be 'verify'
+              %% We need to dump the output somewhere since erlfmt has no
+              %% concept of verify / check / etc.
+              filename:join("/tmp", File);
+          OutputDir ->
+              filename:join(filename:absname(OutputDir), File)
+        end,
+    OutFile =
+        case Out of
+          replace ->
+              File;
+          Out ->
+              Out
+        end,
 
     {ok, Code} = file:read_file(File),
 
-    Pragma = case maps:get(require_pragma, OptionsMap, false) of
-               true ->
-                   require;
-               false ->
-                   ignore
-             end,
+    Pragma =
+        case maps:get(require_pragma, OptionsMap, false) of
+          true ->
+              require;
+          false ->
+              ignore
+        end,
     try erlfmt:format_file(File, {Pragma, Out}) of
       skip ->
           unchanged;

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -383,15 +383,17 @@ lay_postcomments(Cs, D) -> beside(D, floating(break(stack_comments(Cs, true)), 1
 
 stack_comments([C | Cs], Pad) ->
     D = stack_comment_lines(erl_syntax:comment_text(C)),
-    D1 = case Pad of
-           true ->
-               P = case erl_syntax:comment_padding(C) of
-                     none -> ?PADDING;
-                     P1 -> P1
-                   end,
-               beside(text(spaces(P)), D);
-           false -> D
-         end,
+    D1 =
+        case Pad of
+          true ->
+              P =
+                  case erl_syntax:comment_padding(C) of
+                    none -> ?PADDING;
+                    P1 -> P1
+                  end,
+              beside(text(spaces(P)), D);
+          false -> D
+        end,
     case Cs of
       [] ->
           D1; % done
@@ -424,16 +426,18 @@ lay_no_comments(Node, Ctxt) ->
       string -> lay_string(erl_syntax:string_literal(Node, Ctxt#ctxt.encoding), Ctxt);
       nil -> text("[]");
       tuple ->
-          Es = seq(erl_syntax:tuple_elements(Node),
-                   lay_text_float(","),
-                   reset_prec(Ctxt),
-                   fun lay/2),
+          Es =
+              seq(erl_syntax:tuple_elements(Node),
+                  lay_text_float(","),
+                  reset_prec(Ctxt),
+                  fun lay/2),
           beside(lay_text_float("{"), beside(par(Es), lay_text_float("}")));
       list ->
           Ctxt1 = reset_prec(Ctxt),
           Node1 = erl_syntax:compact_list(Node),
           D1 = par(seq(erl_syntax:list_prefix(Node1), lay_text_float(","), Ctxt1, fun lay/2)),
-          D = case erl_syntax:list_suffix(Node1) of
+          D =
+              case erl_syntax:list_suffix(Node1) of
                 none -> beside(D1, lay_text_float("]"));
                 S ->
                     follow(D1,
@@ -443,10 +447,11 @@ lay_no_comments(Node, Ctxt) ->
       operator -> lay_text_float(erl_syntax:operator_literal(Node));
       infix_expr ->
           Operator = erl_syntax:infix_expr_operator(Node),
-          {PrecL, Prec, PrecR} = case erl_syntax:type(Operator) of
-                                   operator -> inop_prec(erl_syntax:operator_name(Operator));
-                                   _ -> {0, 0, 0}
-                                 end,
+          {PrecL, Prec, PrecR} =
+              case erl_syntax:type(Operator) of
+                operator -> inop_prec(erl_syntax:operator_name(Operator));
+                _ -> {0, 0, 0}
+              end,
           D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
           D2 = lay(Operator, reset_prec(Ctxt)),
           D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
@@ -454,27 +459,30 @@ lay_no_comments(Node, Ctxt) ->
           maybe_parentheses(D4, Prec, Ctxt);
       prefix_expr ->
           Operator = erl_syntax:prefix_expr_operator(Node),
-          {{Prec, PrecR}, Name} = case erl_syntax:type(Operator) of
-                                    operator ->
-                                        N = erl_syntax:operator_name(Operator),
-                                        {preop_prec(N), N};
-                                    _ -> {{0, 0}, any}
-                                  end,
+          {{Prec, PrecR}, Name} =
+              case erl_syntax:type(Operator) of
+                operator ->
+                    N = erl_syntax:operator_name(Operator),
+                    {preop_prec(N), N};
+                _ -> {{0, 0}, any}
+              end,
           D1 = lay(Operator, reset_prec(Ctxt)),
           D2 = lay(erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
-          D3 = case Name of
-                 '+' -> beside(D1, D2);
-                 '-' -> beside(D1, D2);
-                 _ -> par([D1, D2], Ctxt#ctxt.sub_indent)
-               end,
+          D3 =
+              case Name of
+                '+' -> beside(D1, D2);
+                '-' -> beside(D1, D2);
+                _ -> par([D1, D2], Ctxt#ctxt.sub_indent)
+              end,
           maybe_parentheses(D3, Prec, Ctxt);
       application ->
           {PrecL, Prec} = func_prec(),
           D = lay(erl_syntax:application_operator(Node), set_prec(Ctxt, PrecL)),
-          As = seq(erl_syntax:application_arguments(Node),
-                   floating(text(",")),
-                   reset_prec(Ctxt),
-                   fun lay/2),
+          As =
+              seq(erl_syntax:application_arguments(Node),
+                  floating(text(",")),
+                  reset_prec(Ctxt),
+                  fun lay/2),
           D1 = beside(D, beside(text("("), beside(par(As), floating(text(")"))))),
           maybe_parentheses(D1, Prec, Ctxt);
       match_expr ->
@@ -488,10 +496,11 @@ lay_no_comments(Node, Ctxt) ->
           %% The style used for a clause depends on its context
           Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
           D1 = par(seq(erl_syntax:clause_patterns(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          D2 = case erl_syntax:clause_guard(Node) of
-                 none -> none;
-                 G -> lay(G, Ctxt1)
-               end,
+          D2 =
+              case erl_syntax:clause_guard(Node) of
+                none -> none;
+                G -> lay(G, Ctxt1)
+              end,
           D3 = sep(seq(erl_syntax:clause_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
           case Ctxt#ctxt.clause of
             fun_expr -> make_fun_clause(D1, D2, D3, Ctxt);
@@ -558,11 +567,13 @@ lay_no_comments(Node, Ctxt) ->
           %% attribute name, without following parentheses.
           Ctxt1 = reset_prec(Ctxt),
           Args = erl_syntax:attribute_arguments(Node),
-          N = case erl_syntax:attribute_name(Node) of
+          N =
+              case erl_syntax:attribute_name(Node) of
                 {atom, _, 'if'} -> erl_syntax:variable('if');
                 N0 -> N0
               end,
-          D = case attribute_type(Node) of
+          D =
+              case attribute_type(Node) of
                 spec ->
                     [SpecTuple] = Args,
                     [FuncName, FuncTypes] = erl_syntax:tuple_elements(SpecTuple),
@@ -602,10 +613,11 @@ lay_no_comments(Node, Ctxt) ->
       binary_field ->
           Ctxt1 = set_prec(Ctxt, max_prec()),
           D1 = lay(erl_syntax:binary_field_body(Node), Ctxt1),
-          D2 = case erl_syntax:binary_field_types(Node) of
-                 [] -> empty();
-                 Ts -> beside(lay_text_float("/"), lay_bit_types(Ts, Ctxt1))
-               end,
+          D2 =
+              case erl_syntax:binary_field_types(Node) of
+                [] -> empty();
+                Ts -> beside(lay_text_float("/"), lay_bit_types(Ts, Ctxt1))
+              end,
           beside(D1, D2);
       block_expr ->
           Ctxt1 = reset_prec(Ctxt),
@@ -683,7 +695,8 @@ lay_no_comments(Node, Ctxt) ->
           %% prefixed with a "?".
           Ctxt1 = reset_prec(Ctxt),
           N = erl_syntax:macro_name(Node),
-          D = case erl_syntax:macro_arguments(Node) of
+          D =
+              case erl_syntax:macro_arguments(Node) of
                 none -> lay(N, Ctxt1);
                 Args ->
                     As = seq(Args, lay_text_float(","), set_prec(Ctxt1, max_prec()), fun lay/2),
@@ -699,23 +712,25 @@ lay_no_comments(Node, Ctxt) ->
       receive_expr ->
           Ctxt1 = reset_prec(Ctxt),
           D1 = lay_clauses(erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
-          D2 = case erl_syntax:receive_expr_timeout(Node) of
-                 none -> D1;
-                 T ->
-                     D3 = lay(T, Ctxt1),
-                     A = erl_syntax:receive_expr_action(Node),
-                     D4 = sep(seq(A, lay_text_float(","), Ctxt1, fun lay/2)),
-                     sep([D1,
-                          follow(lay_text_float("after"),
-                                 append_clause_body(D4, D3, Ctxt1),
-                                 Ctxt1#ctxt.sub_indent)])
-               end,
+          D2 =
+              case erl_syntax:receive_expr_timeout(Node) of
+                none -> D1;
+                T ->
+                    D3 = lay(T, Ctxt1),
+                    A = erl_syntax:receive_expr_action(Node),
+                    D4 = sep(seq(A, lay_text_float(","), Ctxt1, fun lay/2)),
+                    sep([D1,
+                         follow(lay_text_float("after"),
+                                append_clause_body(D4, D3, Ctxt1),
+                                Ctxt1#ctxt.sub_indent)])
+              end,
           sep([text("receive"), nest(Ctxt1#ctxt.sub_indent, D2), text("end")]);
       record_access ->
           {PrecL, Prec, PrecR} = inop_prec('#'),
           D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
-          D2 = beside(lay_text_float("."),
-                      lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
+          D2 =
+              beside(lay_text_float("."),
+                     lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
           T = erl_syntax:record_access_type(Node),
           D3 = beside(beside(lay_text_float("#"), lay(T, reset_prec(Ctxt))), D2),
           maybe_parentheses(beside(D1, D3), Prec, Ctxt);
@@ -723,8 +738,9 @@ lay_no_comments(Node, Ctxt) ->
           Ctxt1 = reset_prec(Ctxt),
           D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
           D2 = par(seq(erl_syntax:record_expr_fields(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          D3 = beside(beside(lay_text_float("#"), D1),
-                      beside(text("{"), beside(D2, lay_text_float("}")))),
+          D3 =
+              beside(beside(lay_text_float("#"), D1),
+                     beside(text("{"), beside(D2, lay_text_float("}")))),
           Arg = erl_syntax:record_expr_argument(Node),
           lay_expr_argument(Arg, D3, Ctxt);
       record_field ->
@@ -771,24 +787,27 @@ lay_no_comments(Node, Ctxt) ->
           Ctxt1 = reset_prec(Ctxt),
           D1 = sep(seq(erl_syntax:try_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
           Es0 = [text("end")],
-          Es1 = case erl_syntax:try_expr_after(Node) of
-                  [] -> Es0;
-                  As ->
-                      D2 = sep(seq(As, lay_text_float(","), Ctxt1, fun lay/2)),
-                      [text("after"), nest(Ctxt1#ctxt.sub_indent, D2) | Es0]
-                end,
-          Es2 = case erl_syntax:try_expr_handlers(Node) of
-                  [] -> Es1;
-                  Hs ->
-                      D3 = lay_clauses(Hs, try_expr, Ctxt1),
-                      [text("catch"), nest(Ctxt1#ctxt.sub_indent, D3) | Es1]
-                end,
-          Es3 = case erl_syntax:try_expr_clauses(Node) of
-                  [] -> Es2;
-                  Cs ->
-                      D4 = lay_clauses(Cs, try_expr, Ctxt1),
-                      [text("of"), nest(Ctxt1#ctxt.sub_indent, D4) | Es2]
-                end,
+          Es1 =
+              case erl_syntax:try_expr_after(Node) of
+                [] -> Es0;
+                As ->
+                    D2 = sep(seq(As, lay_text_float(","), Ctxt1, fun lay/2)),
+                    [text("after"), nest(Ctxt1#ctxt.sub_indent, D2) | Es0]
+              end,
+          Es2 =
+              case erl_syntax:try_expr_handlers(Node) of
+                [] -> Es1;
+                Hs ->
+                    D3 = lay_clauses(Hs, try_expr, Ctxt1),
+                    [text("catch"), nest(Ctxt1#ctxt.sub_indent, D3) | Es1]
+              end,
+          Es3 =
+              case erl_syntax:try_expr_clauses(Node) of
+                [] -> Es2;
+                Cs ->
+                    D4 = lay_clauses(Cs, try_expr, Ctxt1),
+                    [text("of"), nest(Ctxt1#ctxt.sub_indent, D4) | Es2]
+              end,
           sep([par([follow(text("try"), D1, Ctxt1#ctxt.sub_indent), hd(Es3)]) | tl(Es3)]);
       warning_marker ->
           E = erl_syntax:warning_marker_info(Node),
@@ -822,10 +841,12 @@ lay_no_comments(Node, Ctxt) ->
           Ctxt1 = set_prec(Ctxt, max_prec()),
           M = erl_syntax:bitstring_type_m(Node),
           N = erl_syntax:bitstring_type_n(Node),
-          D1 = [beside(text("_:"), lay(M, Ctxt1))
-                || erl_syntax:type(M) =/= integer orelse erl_syntax:integer_value(M) =/= 0],
-          D2 = [beside(text("_:_*"), lay(N, Ctxt1))
-                || erl_syntax:type(N) =/= integer orelse erl_syntax:integer_value(N) =/= 0],
+          D1 =
+              [beside(text("_:"), lay(M, Ctxt1))
+               || erl_syntax:type(M) =/= integer orelse erl_syntax:integer_value(M) =/= 0],
+          D2 =
+              [beside(text("_:_*"), lay(N, Ctxt1))
+               || erl_syntax:type(N) =/= integer orelse erl_syntax:integer_value(N) =/= 0],
           F = fun (D, _) -> D end,
           D = seq(D1 ++ D2, lay_text_float(","), Ctxt1, F),
           beside(lay_text_float("<<"), beside(par(D), lay_text_float(">>")));
@@ -837,17 +858,19 @@ lay_no_comments(Node, Ctxt) ->
           D2 = lay(erl_syntax:constrained_function_type_argument(Node), Ctxt2),
           beside(D1, beside(lay_text_float(" when "), D2));
       function_type ->
-          {Before, After} = case Ctxt#ctxt.clause of
-                              spec -> {"", ""};
-                              _ -> {"fun(", ")"}
-                            end,
+          {Before, After} =
+              case Ctxt#ctxt.clause of
+                spec -> {"", ""};
+                _ -> {"fun(", ")"}
+              end,
           Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
-          D1 = case erl_syntax:function_type_arguments(Node) of
-                 any_arity -> text("(...)");
-                 Arguments ->
-                     As = seq(Arguments, lay_text_float(","), Ctxt1, fun lay/2),
-                     beside(text("("), beside(par(As), lay_text_float(")")))
-               end,
+          D1 =
+              case erl_syntax:function_type_arguments(Node) of
+                any_arity -> text("(...)");
+                Arguments ->
+                    As = seq(Arguments, lay_text_float(","), Ctxt1, fun lay/2),
+                    beside(text("("), beside(par(As), lay_text_float(")")))
+              end,
           D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
           beside(lay_text_float(Before),
                  beside(D1, beside(lay_text_float(" -> "), beside(D2, lay_text_float(After)))));
@@ -891,10 +914,11 @@ lay_no_comments(Node, Ctxt) ->
       record_type ->
           {Prec, _PrecR} = type_preop_prec('#'),
           D1 = beside(text("#"), lay(erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
-          Es = seq(erl_syntax:record_type_fields(Node),
-                   lay_text_float(","),
-                   reset_prec(Ctxt),
-                   fun lay/2),
+          Es =
+              seq(erl_syntax:record_type_fields(Node),
+                  lay_text_float(","),
+                  reset_prec(Ctxt),
+                  fun lay/2),
           D2 = beside(D1, beside(text("{"), beside(par(Es), lay_text_float("}")))),
           maybe_parentheses(D2, Prec, Ctxt);
       record_type_field ->
@@ -911,10 +935,11 @@ lay_no_comments(Node, Ctxt) ->
           end;
       type_union ->
           {_, Prec, PrecR} = type_inop_prec('|'),
-          Es = par(seq(erl_syntax:type_union_types(Node),
-                       lay_text_float(" |"),
-                       set_prec(Ctxt, PrecR),
-                       fun lay/2)),
+          Es =
+              par(seq(erl_syntax:type_union_types(Node),
+                      lay_text_float(" |"),
+                      set_prec(Ctxt, PrecR),
+                      fun lay/2)),
           maybe_parentheses(Es, Prec, Ctxt);
       user_type_application ->
           lay_type_application(erl_syntax:user_type_application_name(Node),
@@ -950,14 +975,16 @@ get_func_node(Node) ->
     end.
 
 unfold_function_names(Ns) ->
-    F = fun ({Atom, Arity}) ->
+    F =
+        fun ({Atom, Arity}) ->
                 erl_syntax:arity_qualifier(erl_syntax:atom(Atom), erl_syntax:integer(Arity))
         end,
     erl_syntax:list([F(N) || N <- Ns]).
 
 %% Macros are not handled well.
 dodge_macros(Type) ->
-    F = fun (T) ->
+    F =
+        fun (T) ->
                 case erl_syntax:type(T) of
                   macro ->
                       Var = erl_syntax:macro_name(T),
@@ -1074,10 +1101,11 @@ make_case_clause(P, G, B, Ctxt) -> append_clause_body(B, append_guard(G, P, Ctxt
 
 make_if_clause(_P, G, B, Ctxt) ->
     %% We ignore the patterns; they should be empty anyway.
-    G1 = case G of
-           none -> text("true");
-           _ -> G
-         end,
+    G1 =
+        case G of
+          none -> text("true");
+          _ -> G
+        end,
     append_clause_body(B, G1, Ctxt).
 
 append_clause_body(B, D, Ctxt) -> append_clause_body(B, D, lay_text_float(" ->"), Ctxt).

--- a/src/formatters/sr_formatter.erl
+++ b/src/formatters/sr_formatter.erl
@@ -31,14 +31,15 @@ format_file(File, #{opts := GlobalOpts}, OptionsMap) ->
     %%       1. Opts are treated as a proplist in steamroller
     %%       2. steamroller:opts/2 doesn't override opts, it just adds defaults
     Opts = parse_opts(OptionsMap) ++ GlobalOpts,
-    FileToFormat = case maps:get(output_dir, OptionsMap, current) of
-                     current ->
-                         File;
-                     none ->
-                         File;
-                     OutputDir ->
-                         copy_file(File, OutputDir)
-                   end,
+    FileToFormat =
+        case maps:get(output_dir, OptionsMap, current) of
+          current ->
+              File;
+          none ->
+              File;
+          OutputDir ->
+              copy_file(File, OutputDir)
+        end,
     {ok, Code} = file:read_file(FileToFormat),
     case steamroller:format_file(iolist_to_binary(FileToFormat), Opts) of
       ok ->

--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -19,12 +19,13 @@ format(File, Formatter, Opts) ->
     Comments = get_comments(File),
     {ok, Original} = file:read_file(File),
     Formatted = format(File, AST, Formatter, Comments, Opts),
-    Result = case Formatted of
-               Original ->
-                   unchanged;
-               _ ->
-                   changed
-             end,
+    Result =
+        case Formatted of
+          Original ->
+              unchanged;
+          _ ->
+              changed
+        end,
     case maybe_save_file(maps:get(output_dir, Opts), File, Formatted) of
       none ->
           Result;
@@ -79,16 +80,17 @@ empty_lines(File) ->
     {ok, Data} = file:read_file(File),
     List = binary:split(Data, [<<"\n">>], [global, trim]),
     {ok, NonEmptyLineRe} = re:compile("\\S"),
-    {Res, _} = lists:foldl(fun (Line, {EmptyLines, N}) ->
-                                   case re:run(Line, NonEmptyLineRe) of
-                                     {match, _} ->
-                                         {EmptyLines, N + 1};
-                                     nomatch ->
-                                         {[N | EmptyLines], N + 1}
-                                   end
-                           end,
-                           {[], 1},
-                           List),
+    {Res, _} =
+        lists:foldl(fun (Line, {EmptyLines, N}) ->
+                            case re:run(Line, NonEmptyLineRe) of
+                              {match, _} ->
+                                  {EmptyLines, N + 1};
+                              nomatch ->
+                                  {[N | EmptyLines], N + 1}
+                            end
+                    end,
+                    {[], 1},
+                    List),
     lists:reverse(Res).
 
 insert_last_line(Formatted) ->

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -6,25 +6,26 @@
 %% @private
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-    Provider = providers:create([{name, format},
-                                 {module, rebar3_format_prv},
-                                 {bare, true},
-                                 {deps, [app_discovery]},
-                                 {example, "rebar3 format"},
-                                 {opts,
-                                  [{files,
-                                    $f,
-                                    "files",
-                                    string,
-                                    "List of files and directories to be formatted"},
-                                   {verify, $v, "verify", boolean, "Just verify, don't format"},
-                                   {output,
-                                    $o,
-                                    "output",
-                                    string,
-                                    "Output directory for the formatted files"}]},
-                                 {short_desc, "A rebar plugin for code formatting"},
-                                 {desc, ""}]),
+    Provider =
+        providers:create([{name, format},
+                          {module, rebar3_format_prv},
+                          {bare, true},
+                          {deps, [app_discovery]},
+                          {example, "rebar3 format"},
+                          {opts,
+                           [{files,
+                             $f,
+                             "files",
+                             string,
+                             "List of files and directories to be formatted"},
+                            {verify, $v, "verify", boolean, "Just verify, don't format"},
+                            {output,
+                             $o,
+                             "output",
+                             string,
+                             "Output directory for the formatted files"}]},
+                          {short_desc, "A rebar plugin for code formatting"},
+                          {desc, ""}]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
 %% @private
@@ -53,8 +54,9 @@ format_error({unformatted_files, Files}) ->
     Msg = "The following files are not properly formatted:\n~p",
     io_lib:format(Msg, [Files]);
 format_error({erl_parse, File, Error}) ->
-    Msg = "Error while parsing ~s: ~p.\n\tTry running with DEBUG=1 for "
-          "more information",
+    Msg =
+        "Error while parsing ~s: ~p.\n\tTry running with DEBUG=1 for "
+        "more information",
     io_lib:format(Msg, [File, Error]);
 format_error(Reason) ->
     io_lib:format("Unknown Formatting Error: ~p", [Reason]).
@@ -70,18 +72,19 @@ get_action(Args) ->
 
 -spec get_files(proplists:proplist(), rebar_state:t()) -> [file:filename_all()].
 get_files(Args, State) ->
-    Patterns = case lists:keyfind(files, 1, Args) of
-                 {files, Wildcard} ->
-                     [Wildcard];
-                 false ->
-                     FormatConfig = rebar_state:get(State, format, []),
-                     case proplists:get_value(files, FormatConfig, undefined) of
-                       undefined ->
-                           ["src/**/*.[he]rl"];
-                       Wildcards ->
-                           Wildcards
-                     end
-               end,
+    Patterns =
+        case lists:keyfind(files, 1, Args) of
+          {files, Wildcard} ->
+              [Wildcard];
+          false ->
+              FormatConfig = rebar_state:get(State, format, []),
+              case proplists:get_value(files, FormatConfig, undefined) of
+                undefined ->
+                    ["src/**/*.[he]rl"];
+                Wildcards ->
+                    Wildcards
+              end
+        end,
     [File || Pattern <- Patterns, File <- filelib:wildcard(Pattern)].
 
 -spec get_ignored_files(rebar_state:t()) -> [file:filename_all()].
@@ -105,9 +108,8 @@ get_output_dir(Action, Args) ->
 
 -spec get_formatter(rebar_state:t(), rebar3_formatter:opts()) -> rebar3_formatter:t().
 get_formatter(State, Opts) ->
-    Module = proplists:get_value(formatter,
-                                 rebar_state:get(State, format, []),
-                                 default_formatter),
+    Module =
+        proplists:get_value(formatter, rebar_state:get(State, format, []), default_formatter),
     rebar3_formatter:new(Module, Opts, State).
 
 -spec get_opts(rebar_state:t()) -> rebar3_formatter:opts().

--- a/src/rebar3_formatter.erl
+++ b/src/rebar3_formatter.erl
@@ -65,8 +65,9 @@ apply_per_file_opts(File, Opts) ->
       true ->
           ignore;
       false ->
-          MergeF = fun (Map, Acc) ->
-                           maps:merge(Acc, Map)
-                   end,
+          MergeF =
+              fun (Map, Acc) ->
+                      maps:merge(Acc, Map)
+              end,
           lists:foldl(MergeF, Opts, FileOpts)
     end.

--- a/test/erlfmt.erl
+++ b/test/erlfmt.erl
@@ -13,9 +13,10 @@ validator(Fun) ->
 
 -spec format_file(file:name_all(), out()) -> {ok, [error_info()]} | {error, error_info()}.
 format_file(File, Opts) ->
-    Validator = application:get_env(rebar3_format,
-                                    erlfmt_formatter_validator,
-                                    fun (_, _) ->
-                                            ok
-                                    end),
+    Validator =
+        application:get_env(rebar3_format,
+                            erlfmt_formatter_validator,
+                            fun (_, _) ->
+                                    ok
+                            end),
     Validator(File, Opts).

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -84,8 +84,8 @@ pragma(_Config) ->
                              ignore = Pragma,
                              {ok, []}
                      end),
-    Args3 = rebar_state:command_parsed_args(init(#{require_pragma => false}),
-                                            {[], something}),
+    Args3 =
+        rebar_state:command_parsed_args(init(#{require_pragma => false}), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args3).
 
 init() ->

--- a/test/steamroller.erl
+++ b/test/steamroller.erl
@@ -14,9 +14,10 @@ validator(Fun) ->
 
 -spec format_file(binary(), [any()]) -> ok | {error, any()}.
 format_file(File, Opts) ->
-    Validator = application:get_env(rebar3_format,
-                                    steamroller_formatter_validator,
-                                    fun (_, _) ->
-                                            ok
-                                    end),
+    Validator =
+        application:get_env(rebar3_format,
+                            steamroller_formatter_validator,
+                            fun (_, _) ->
+                                    ok
+                            end),
     Validator(File, Opts).

--- a/test_app/after/src/brackets.erl
+++ b/test_app/after/src/brackets.erl
@@ -28,14 +28,16 @@ long_tuple() ->
      needs, indentation}.
 
 nested() ->
-    First = {a, long, long, tuple, with,
-             [a, really, very, long, long, list,
-              in, it],
-             plus, other, things},
-    Then = [a, long, long, list, with,
-            {a, really, very, long, long, tuple,
-             in, it},
-            plus, other, things],
+    First =
+        {a, long, long, tuple, with,
+         [a, really, very, long, long, list, in,
+          it],
+         plus, other, things},
+    Then =
+        [a, long, long, list, with,
+         {a, really, very, long, long, tuple, in,
+          it},
+         plus, other, things],
     finally:a_long_function_call(with, many,
                                  arguments, like,
                                  First, Then,

--- a/test_app/after/src/indent_18.erl
+++ b/test_app/after/src/indent_18.erl
@@ -21,8 +21,8 @@ infix_expr() ->
                  using:sub_indent(8).
 
 prefix_expr() ->
- ThisPrefixExpressionShould = not
-                                      use:break_indent(1).
+ ThisPrefixExpressionShould =
+  not use:break_indent(1).
 
 match_expr() ->
  ThisVeryVeryVeryLongMatchExpression =

--- a/test_app/after/src/indent_81.erl
+++ b/test_app/after/src/indent_81.erl
@@ -21,8 +21,8 @@ infix_expr() ->
           using:sub_indent(1).
 
 prefix_expr() ->
-        ThisPrefixExpressionShould = not
-                                      use:break_indent(8).
+        ThisPrefixExpressionShould =
+                not use:break_indent(8).
 
 match_expr() ->
         ThisVeryVeryVeryLongMatchExpression =

--- a/test_app/after/src/inline_items.erl
+++ b/test_app/after/src/inline_items.erl
@@ -81,7 +81,8 @@ short_map() ->
 
 -spec long_tuple() -> {T, T, T} when T :: {x, y, z}.
 long_tuple() ->
-    X = {x1,
+    X =
+        {x1,
          x2,
          x3,
          x4,
@@ -92,7 +93,8 @@ long_tuple() ->
          very_very_long_name_1,
          very_very_long_name_2,
          very_very_long_name_3},
-    Y = {x1,
+    Y =
+        {x1,
          x2,
          x3,
          x4,
@@ -129,7 +131,8 @@ long_tuple() ->
                                           very_very_long_name_2 |
                                           very_very_long_name_3].
 long_list() ->
-    X = [x1,
+    X =
+        [x1,
          x2,
          x3,
          x4,
@@ -140,7 +143,8 @@ long_list() ->
          very_very_long_name_1,
          very_very_long_name_2,
          very_very_long_name_3],
-    Y = [x1,
+    Y =
+        [x1,
          x2,
          x3,
          x4,
@@ -214,7 +218,8 @@ long_fun() ->
 
 -spec long_bin() -> binary().
 long_bin() ->
-    X = <<1,
+    X =
+        <<1,
           1,
           1,
           1,
@@ -226,7 +231,8 @@ long_bin() ->
           333333333333333333,
           333333333333333333,
           333333333333333333>>,
-    Y = <<1:1,
+    Y =
+        <<1:1,
           1:1,
           1:1,
           1:1,

--- a/test_app/after/src/others.erl
+++ b/test_app/after/src/others.erl
@@ -22,12 +22,13 @@ catch_expr() ->
     catch this:train(with, all, its, arguments, {they, might, be, too, many, to, "handle"}).
 
 comprehensions(Bin, List) ->
-    BinToBin = << <<X:1>>
-                   || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
-    BinToList = [X
-                 || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X)],
-    ListToBin = << <<X:1>>
-                    || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
+    BinToBin =
+        << <<X:1>>
+            || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
+    BinToList =
+        [X || <<X:8/integer>> <= Bin, X > 0, with:a_very(complex, boolean_filter, on, X)],
+    ListToBin =
+        << <<X:1>>  || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X) >>,
     ListToList = [X || X <- List, X > 0, with:a_very(complex, boolean_filter, on, X)],
     {BinToBin, BinToList, ListToBin, ListToList}.
 

--- a/test_app/after/src/weird.erl
+++ b/test_app/after/src/weird.erl
@@ -16,10 +16,11 @@ nospaces(_) ->
 
 -spec newlines(Num :: integer()) -> list().
 newlines(Num) ->
-    List = [{X, Y}
-            || X <- lists:seq(1, Num),
-               % Weird comment here!
-               Y <- [a, b]],
+    List =
+        [{X, Y}
+         || X <- lists:seq(1, Num),
+            % Weird comment here!
+            Y <- [a, b]],
     io:format("~p~n", [List]),
     List.
 


### PR DESCRIPTION
Fixes #75 by indenting long matching expressions on `=`.