### PR TITLE
[Fix #105] Adjust to OTP23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
 
 otp_release:
-   - 21.3
+   - 22.3
+   - 23.0
 
 notifications:
   email: rtb-team+travis@adroll.com

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -774,6 +774,7 @@ lay_no_comments(Node, Ctxt) ->
           D1 = lay(erl_syntax:typed_record_field_body(Node), Ctxt1),
           D2 = lay(erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
           D3 = par([D1, lay_text_float(" ::"), D2], Ctxt1#ctxt.break_indent),
+          D3 = par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent),
           maybe_parentheses(D3, Prec, Ctxt);
       try_expr ->
           Ctxt1 = reset_prec(Ctxt),

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -453,7 +453,7 @@ lay_no_comments(Node, Ctxt) ->
           D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
           D2 = lay(Operator, reset_prec(Ctxt)),
           D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
-          D4 = par([D1, D2, D3], Ctxt#ctxt.sub_indent),
+          D4 = par([D1, D2, D3], Ctxt#ctxt.break_indent),
           maybe_parentheses(D4, Prec, Ctxt);
       prefix_expr ->
           Operator = erl_syntax:prefix_expr_operator(Node),
@@ -470,7 +470,7 @@ lay_no_comments(Node, Ctxt) ->
               case Name of
                 '+' -> beside(D1, D2);
                 '-' -> beside(D1, D2);
-                _ -> par([D1, D2], Ctxt#ctxt.sub_indent)
+                _ -> par([D1, D2], Ctxt#ctxt.break_indent)
               end,
           maybe_parentheses(D3, Prec, Ctxt);
       application ->
@@ -524,18 +524,18 @@ lay_no_comments(Node, Ctxt) ->
           Ctxt1 = reset_prec(Ctxt),
           D1 = lay(erl_syntax:case_expr_argument(Node), Ctxt1),
           D2 = lay_clauses(erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
-          sep([par([follow(text("case"), D1, Ctxt1#ctxt.sub_indent), text("of")],
+          sep([par([follow(text("case"), D1, Ctxt1#ctxt.break_indent), text("of")],
                    Ctxt1#ctxt.break_indent),
-               nest(Ctxt1#ctxt.sub_indent, D2),
+               nest(Ctxt1#ctxt.break_indent, D2),
                text("end")]);
       if_expr ->
           Ctxt1 = reset_prec(Ctxt),
           D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
-          sep([follow(text("if"), D, Ctxt1#ctxt.sub_indent), text("end")]);
+          sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
       cond_expr ->
           Ctxt1 = reset_prec(Ctxt),
           D = lay_clauses(erl_syntax:cond_expr_clauses(Node), cond_expr, Ctxt1),
-          sep([text("cond"), nest(Ctxt1#ctxt.sub_indent, D), text("end")]);
+          sep([text("cond"), nest(Ctxt1#ctxt.break_indent, D), text("end")]);
       fun_expr ->
           Ctxt1 = reset_prec(Ctxt),
           Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
@@ -620,11 +620,11 @@ lay_no_comments(Node, Ctxt) ->
       block_expr ->
           Ctxt1 = reset_prec(Ctxt),
           Es = seq(erl_syntax:block_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2),
-          sep([text("begin"), nest(Ctxt1#ctxt.sub_indent, sep(Es)), text("end")]);
+          sep([text("begin"), nest(Ctxt1#ctxt.break_indent, sep(Es)), text("end")]);
       catch_expr ->
           {Prec, PrecR} = preop_prec('catch'),
           D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
-          D1 = follow(text("catch"), D, Ctxt#ctxt.sub_indent),
+          D1 = follow(text("catch"), D, Ctxt#ctxt.break_indent),
           maybe_parentheses(D1, Prec, Ctxt);
       class_qualifier ->
           Ctxt1 = set_prec(Ctxt, max_prec()),
@@ -720,9 +720,9 @@ lay_no_comments(Node, Ctxt) ->
                     sep([D1,
                          follow(lay_text_float("after"),
                                 append_clause_body(D4, D3, Ctxt1),
-                                Ctxt1#ctxt.sub_indent)])
+                                Ctxt1#ctxt.break_indent)])
               end,
-          sep([text("receive"), nest(Ctxt1#ctxt.sub_indent, D2), text("end")]);
+          sep([text("receive"), nest(Ctxt1#ctxt.break_indent, D2), text("end")]);
       record_access ->
           {PrecL, Prec, PrecR} = inop_prec('#'),
           D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
@@ -790,23 +790,23 @@ lay_no_comments(Node, Ctxt) ->
                 [] -> Es0;
                 As ->
                     D2 = sep(seq(As, lay_text_float(","), Ctxt1, fun lay/2)),
-                    [text("after"), nest(Ctxt1#ctxt.sub_indent, D2) | Es0]
+                    [text("after"), nest(Ctxt1#ctxt.break_indent, D2) | Es0]
               end,
           Es2 =
               case erl_syntax:try_expr_handlers(Node) of
                 [] -> Es1;
                 Hs ->
                     D3 = lay_clauses(Hs, try_expr, Ctxt1),
-                    [text("catch"), nest(Ctxt1#ctxt.sub_indent, D3) | Es1]
+                    [text("catch"), nest(Ctxt1#ctxt.break_indent, D3) | Es1]
               end,
           Es3 =
               case erl_syntax:try_expr_clauses(Node) of
                 [] -> Es2;
                 Cs ->
                     D4 = lay_clauses(Cs, try_expr, Ctxt1),
-                    [text("of"), nest(Ctxt1#ctxt.sub_indent, D4) | Es2]
+                    [text("of"), nest(Ctxt1#ctxt.break_indent, D4) | Es2]
               end,
-          sep([par([follow(text("try"), D1, Ctxt1#ctxt.sub_indent), hd(Es3)]) | tl(Es3)]);
+          sep([par([follow(text("try"), D1, Ctxt1#ctxt.break_indent), hd(Es3)]) | tl(Es3)]);
       warning_marker ->
           E = erl_syntax:warning_marker_info(Node),
           beside(text("%% WARNING: "), lay_error_info(E, reset_prec(Ctxt)));
@@ -1001,7 +1001,7 @@ lay_follow_beside_text_float(D1, D2, Ctxt) ->
     follow(beside(D1, lay_text_float(" ::")), D2, Ctxt#ctxt.break_indent).
 
 lay_fun_sep(Clauses, Ctxt) ->
-    sep([follow(text("fun"), Clauses, Ctxt#ctxt.sub_indent), text("end")]).
+    sep([follow(text("fun"), Clauses, Ctxt#ctxt.break_indent), text("end")]).
 
 lay_expr_argument(none, D, Ctxt) ->
     {_, Prec, _} = inop_prec('#'),

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -49,7 +49,6 @@
 
 -type hook() :: none | fun((erl_syntax:syntaxTree(), _, _) -> prettypr:document()).
 -type clause_t() :: case_expr |
-                    cond_expr |
                     fun_expr |
                     if_expr |
                     receive_expr |
@@ -504,7 +503,6 @@ lay_no_comments(Node, Ctxt) ->
             fun_expr -> make_fun_clause(D1, D2, D3, Ctxt);
             {function, N} -> make_fun_clause(N, D1, D2, D3, Ctxt);
             if_expr -> make_if_clause(D1, D2, D3, Ctxt);
-            cond_expr -> make_if_clause(D1, D2, D3, Ctxt);
             case_expr -> make_case_clause(D1, D2, D3, Ctxt);
             receive_expr -> make_case_clause(D1, D2, D3, Ctxt);
             try_expr -> make_case_clause(D1, D2, D3, Ctxt);
@@ -532,10 +530,6 @@ lay_no_comments(Node, Ctxt) ->
           Ctxt1 = reset_prec(Ctxt),
           D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
           sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
-      cond_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D = lay_clauses(erl_syntax:cond_expr_clauses(Node), cond_expr, Ctxt1),
-          sep([text("cond"), nest(Ctxt1#ctxt.break_indent, D), text("end")]);
       fun_expr ->
           Ctxt1 = reset_prec(Ctxt),
           Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -9,7 +9,14 @@ test_app(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
     {ok, State1} = rebar3_format:init(rebar_state:new()),
     Files = {files, ["src/*.erl", "include/*.hrl"]},
-    IgnoredFiles = {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]},
+    IgnoredFiles =
+        case string:to_integer(erlang:system_info(otp_release)) of
+          {N, []} when N >= 23 ->
+              {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
+          _ ->
+              {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp23.erl"]}
+        end,
+    ct:pal("~p => IgnoredFiles: ~p", [erlang:system_info(otp_release), IgnoredFiles]),
     State2 = rebar_state:set(State1, format, [Files, IgnoredFiles]),
     {error, _} = verify(State2),
     {ok, _} = format(State2),

--- a/test_app/after/src/otp23.erl
+++ b/test_app/after/src/otp23.erl
@@ -1,0 +1,26 @@
+%% @doc New stuff introduced in OTP23.
+-module(otp23).
+
+-export([underscores/0, eep52_1/1, eep52_3/1, eep52_5/2, eep52_6/2]).
+
+underscores() ->
+    #{1_2_3_4 := X} = #{1_2_3_4 => 5_6_7},
+    X = 567.
+
+eep52_1(<<Size:8, Payload:((Size - 1) * 8)/binary, Rest/binary>>) ->
+    {Payload, Rest}.
+
+eep52_3(<<X:(1 / 0)>>) ->
+    X;
+eep52_3(<<X:not_integer>>) ->
+    X;
+eep52_3(_) ->
+    no_match.
+
+eep52_5(M, X) ->
+    #{{tag, X} := Value} = M,
+    Value.
+
+eep52_6(Bin, V) ->
+    <<X:(is_list(V))>> = Bin,
+    X.

--- a/test_app/src/otp23.erl
+++ b/test_app/src/otp23.erl
@@ -1,0 +1,26 @@
+%% @doc New stuff introduced in OTP23.
+-module(otp23).
+
+-export([underscores/0, eep52_1/1, eep52_3/1, eep52_5/2, eep52_6/2]).
+
+underscores() ->
+    #{1_2_3_4 := X} = #{1_2_3_4 => 5_6_7},
+    X = 567.
+
+eep52_1(<<Size:8, Payload:((Size - 1) * 8)/binary, Rest/binary>>) ->
+    {Payload, Rest}.
+
+eep52_3(<<X:(1 / 0)>>) ->
+    X;
+eep52_3(<<X:not_integer>>) ->
+    X;
+eep52_3(_) ->
+    no_match.
+
+eep52_5(M, X) ->
+    #{{tag, X} := Value} = M,
+    Value.
+
+eep52_6(Bin, V) ->
+    <<X:(is_list(V))>> = Bin,
+    X.


### PR DESCRIPTION
- Apply https://github.com/erlang/otp/commit/d1c8f8c811662e7e6209c57abec651209459a701 and other newer commits to `otp_formatter`.
- Add tests for OTP23-style features.

[Fix #105] 