### PR TITLE
Remove sub_indent altogether from the default_formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ The plugin supports the following configuration options in the `format` section 
         + `break_indent`(`pos_integer()`):
             * Specifies the preferred number of characters to use to indent a line that "breaks" from the previous one (for instance, a clause body after a clause head).
             * The default value is `4`.
-        + `sub_indent`(`pos_integer()`):
-            * Specifies the preferred number of characters to use to indent a line that "follows" the current one (for instance, a long clause head or a long function application).
-            * The default value is `2`.
         + `unquote_atoms` (`boolean()`):
             * Specifies whether the formatter should remove quotes from atoms that don't need them (e.g. `'this_one'`) or not.
             * The default value is `true`, i.e. the formatter won't preserve your quotes if they're not needed, unless you explicitely ask for.

--- a/src/formatters/erlfmt_formatter.erl
+++ b/src/formatters/erlfmt_formatter.erl
@@ -21,66 +21,66 @@ init(_, _) ->
 format_file(File, nostate, OptionsMap) ->
     Out =
         case maps:get(output_dir, OptionsMap, current) of
-          current -> %% Action can only be 'format'
-              replace;
-          none ->
-              %% Action can only be 'verify'
-              %% We need to dump the output somewhere since erlfmt has no
-              %% concept of verify / check / etc.
-              filename:join("/tmp", File);
-          OutputDir ->
-              filename:join(filename:absname(OutputDir), File)
+            current -> %% Action can only be 'format'
+                replace;
+            none ->
+                %% Action can only be 'verify'
+                %% We need to dump the output somewhere since erlfmt has no
+                %% concept of verify / check / etc.
+                filename:join("/tmp", File);
+            OutputDir ->
+                filename:join(filename:absname(OutputDir), File)
         end,
     OutFile =
         case Out of
-          replace ->
-              File;
-          Out ->
-              Out
+            replace ->
+                File;
+            Out ->
+                Out
         end,
 
     {ok, Code} = file:read_file(File),
 
     Pragma =
         case maps:get(require_pragma, OptionsMap, false) of
-          true ->
-              require;
-          false ->
-              case maps:get(insert_pragma, OptionsMap, false) of
-                true ->
-                    insert;
-                false ->
-                    ignore
-              end
+            true ->
+                require;
+            false ->
+                case maps:get(insert_pragma, OptionsMap, false) of
+                    true ->
+                        insert;
+                    false ->
+                        ignore
+                end
         end,
     try erlfmt:format_file(File, {Pragma, Out}) of
-      skip ->
-          unchanged;
-      {ok, _} ->
-          case file:read_file(OutFile) of
-            {ok, Code} ->
-                unchanged;
-            {ok, _} ->
-                changed
-          end;
-      {error, Reason} ->
-          erlang:error(Reason)
+        skip ->
+            unchanged;
+        {ok, _} ->
+            case file:read_file(OutFile) of
+                {ok, Code} ->
+                    unchanged;
+                {ok, _} ->
+                    changed
+            end;
+        {error, Reason} ->
+            erlang:error(Reason)
     catch
-      error:function_clause ->
-          try erlfmt:format_file(File, Out) of
-            {ok, _} ->
-                case file:read_file(OutFile) of
-                  {ok, Code} ->
-                      unchanged;
-                  {ok, _} ->
-                      changed
-                end;
-            {error, Reason} ->
-                erlang:error(Reason)
-          catch
-            _:{error, Reason} ->
-                erlang:error(Reason)
-          end;
-      _:{error, Reason} ->
-          erlang:error(Reason)
+        error:function_clause ->
+            try erlfmt:format_file(File, Out) of
+                {ok, _} ->
+                    case file:read_file(OutFile) of
+                        {ok, Code} ->
+                            unchanged;
+                        {ok, _} ->
+                            changed
+                    end;
+                {error, Reason} ->
+                    erlang:error(Reason)
+            catch
+                _:{error, Reason} ->
+                    erlang:error(Reason)
+            end;
+        _:{error, Reason} ->
+            erlang:error(Reason)
     end.

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -346,25 +346,25 @@ layout(Node, Options) ->
 
 lay(Node, Ctxt) ->
     case erl_syntax:get_ann(Node) of
-      [] ->
-          %% Hooks are not called if there are no annotations.
-          do_lay(Node, Ctxt);
-      _As ->
-          case Ctxt#ctxt.hook of
-            ?NOHOOK -> do_lay(Node, Ctxt);
-            Hook -> Hook(Node, Ctxt, fun do_lay/2)
-          end
+        [] ->
+            %% Hooks are not called if there are no annotations.
+            do_lay(Node, Ctxt);
+        _As ->
+            case Ctxt#ctxt.hook of
+                ?NOHOOK -> do_lay(Node, Ctxt);
+                Hook -> Hook(Node, Ctxt, fun do_lay/2)
+            end
     end.
 
 %% This handles attached comments:
 
 do_lay(Node, Ctxt) ->
     case erl_syntax:has_comments(Node) of
-      true ->
-          D1 = lay_no_comments(Node, Ctxt),
-          D2 = lay_postcomments(erl_syntax:get_postcomments(Node), D1),
-          lay_precomments(erl_syntax:get_precomments(Node), D2);
-      false -> lay_no_comments(Node, Ctxt)
+        true ->
+            D1 = lay_no_comments(Node, Ctxt),
+            D2 = lay_postcomments(erl_syntax:get_postcomments(Node), D1),
+            lay_precomments(erl_syntax:get_precomments(Node), D2);
+        false -> lay_no_comments(Node, Ctxt)
     end.
 
 %% For pre-comments, all padding is ignored.
@@ -384,19 +384,19 @@ stack_comments([C | Cs], Pad) ->
     D = stack_comment_lines(erl_syntax:comment_text(C)),
     D1 =
         case Pad of
-          true ->
-              P =
-                  case erl_syntax:comment_padding(C) of
-                    none -> ?PADDING;
-                    P1 -> P1
-                  end,
-              beside(text(spaces(P)), D);
-          false -> D
+            true ->
+                P =
+                    case erl_syntax:comment_padding(C) of
+                        none -> ?PADDING;
+                        P1 -> P1
+                    end,
+                beside(text(spaces(P)), D);
+            false -> D
         end,
     case Cs of
-      [] ->
-          D1; % done
-      _ -> above(D1, stack_comments(Cs, Pad))
+        [] ->
+            D1; % done
+        _ -> above(D1, stack_comments(Cs, Pad))
     end.
 
 %% Stack lines of text above each other and prefix each string in
@@ -405,8 +405,8 @@ stack_comments([C | Cs], Pad) ->
 stack_comment_lines([S | Ss]) ->
     D = text(add_comment_prefix(S)),
     case Ss of
-      [] -> D;
-      _ -> above(D, stack_comment_lines(Ss))
+        [] -> D;
+        _ -> above(D, stack_comment_lines(Ss))
     end;
 stack_comment_lines([]) -> empty().
 
@@ -416,541 +416,548 @@ add_comment_prefix(S) -> [$% | S].
 
 lay_no_comments(Node, Ctxt) ->
     case erl_syntax:type(Node) of
-      %% We list literals and other common cases first.
-      variable -> text(erl_syntax:variable_literal(Node));
-      atom -> text(erl_syntax:atom_literal(Node, Ctxt#ctxt.encoding));
-      integer -> text(tidy_integer(Node));
-      float -> text(tidy_float(Node));
-      char -> text(erl_syntax:char_literal(Node, Ctxt#ctxt.encoding));
-      string -> lay_string(erl_syntax:string_literal(Node, Ctxt#ctxt.encoding), Ctxt);
-      nil -> text("[]");
-      tuple ->
-          Es =
-              seq(erl_syntax:tuple_elements(Node),
-                  lay_text_float(","),
-                  reset_prec(Ctxt),
-                  fun lay/2),
-          beside(lay_text_float("{"), beside(sep(Es), lay_text_float("}")));
-      list ->
-          Ctxt1 = reset_prec(Ctxt),
-          Node1 = erl_syntax:compact_list(Node),
-          D1 = sep(seq(erl_syntax:list_prefix(Node1), lay_text_float(","), Ctxt1, fun lay/2)),
-          D =
-              case erl_syntax:list_suffix(Node1) of
-                none -> beside(D1, lay_text_float("]"));
-                S ->
-                    follow(D1,
-                           beside(lay_text_float("| "), beside(lay(S, Ctxt1), lay_text_float("]"))))
-              end,
-          beside(lay_text_float("["), D);
-      operator -> lay_text_float(erl_syntax:operator_literal(Node));
-      infix_expr ->
-          Operator = erl_syntax:infix_expr_operator(Node),
-          {PrecL, Prec, PrecR} =
-              case erl_syntax:type(Operator) of
-                operator -> inop_prec(erl_syntax:operator_name(Operator));
-                _ -> {0, 0, 0}
-              end,
-          D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
-          D2 = lay(Operator, reset_prec(Ctxt)),
-          D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
-          D4 = par([D1, D2, D3], Ctxt#ctxt.break_indent),
-          maybe_parentheses(D4, Prec, Ctxt);
-      prefix_expr ->
-          Operator = erl_syntax:prefix_expr_operator(Node),
-          {{Prec, PrecR}, Name} =
-              case erl_syntax:type(Operator) of
-                operator ->
-                    N = erl_syntax:operator_name(Operator),
-                    {preop_prec(N), N};
-                _ -> {{0, 0}, any}
-              end,
-          D1 = lay(Operator, reset_prec(Ctxt)),
-          D2 = lay(erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
-          D3 =
-              case Name of
-                '+' -> beside(D1, D2);
-                '-' -> beside(D1, D2);
-                _ -> par([D1, D2], Ctxt#ctxt.break_indent)
-              end,
-          maybe_parentheses(D3, Prec, Ctxt);
-      application ->
-          {PrecL, Prec} = func_prec(),
-          D = lay(erl_syntax:application_operator(Node), set_prec(Ctxt, PrecL)),
-          As =
-              seq(erl_syntax:application_arguments(Node),
-                  floating(text(",")),
-                  reset_prec(Ctxt),
-                  fun lay/2),
-          D1 = beside(D, beside(text("("), beside(sep(As), floating(text(")"))))),
-          maybe_parentheses(D1, Prec, Ctxt);
-      match_expr ->
-          {PrecL, Prec, PrecR} = inop_prec('='),
-          D1 = lay(erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
-          D2 = lay(erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
-          D3 = follow(beside(D1, lay_text_float(" =")), D2, Ctxt#ctxt.break_indent),
-          maybe_parentheses(D3, Prec, Ctxt);
-      underscore -> text("_");
-      clause ->
-          %% The style used for a clause depends on its context
-          Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
-          D1 = par(seq(erl_syntax:clause_patterns(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          D2 =
-              case erl_syntax:clause_guard(Node) of
-                none -> none;
-                G -> lay(G, Ctxt1)
-              end,
-          D3 = lay_clause_expressions(erl_syntax:clause_body(Node), Ctxt1),
-          case Ctxt#ctxt.clause of
-            fun_expr -> make_fun_clause(D1, D2, D3, Ctxt);
-            {function, N} -> make_fun_clause(N, D1, D2, D3, Ctxt);
-            if_expr -> make_if_clause(D1, D2, D3, Ctxt);
-            case_expr -> make_case_clause(D1, D2, D3, Ctxt);
-            receive_expr -> make_case_clause(D1, D2, D3, Ctxt);
-            try_expr -> make_case_clause(D1, D2, D3, Ctxt);
-            undefined ->
-                %% If a clause is formatted out of context, we
-                %% use a "fun-expression" clause style.
-                make_fun_clause(D1, D2, D3, Ctxt)
-          end;
-      function ->
-          %% Comments on the name itself will be repeated for each
-          %% clause, but that seems to be the best way to handle it.
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:function_name(Node), Ctxt1),
-          D2 = lay_clauses(erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
-          beside(D2, lay_text_float("."));
-      case_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:case_expr_argument(Node), Ctxt1),
-          D2 = lay_clauses(erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
-          sep([par([follow(text("case"), D1, Ctxt1#ctxt.break_indent), text("of")],
-                   Ctxt1#ctxt.break_indent),
-               nest(Ctxt1#ctxt.break_indent, D2),
-               text("end")]);
-      if_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
-          sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
-      fun_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
-          lay_fun_sep(Clauses, Ctxt1);
-      named_fun_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:named_fun_expr_name(Node), Ctxt1),
-          Clauses = lay_clauses(erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
-          lay_fun_sep(Clauses, Ctxt1);
-      module_qualifier ->
-          {PrecL, _Prec, PrecR} = inop_prec(':'),
-          D1 = lay(erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
-          D2 = lay(erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
-          beside(D1, beside(text(":"), D2));
-      %%
-      %% The rest is in alphabetical order (except map and types)
-      %%
-      arity_qualifier ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:arity_qualifier_body(Node), Ctxt1),
-          D2 = lay(erl_syntax:arity_qualifier_argument(Node), Ctxt1),
-          beside(D1, beside(text("/"), D2));
-      attribute ->
-          %% The attribute name and arguments are formatted similar to
-          %% a function call, but prefixed with a "-" and followed by
-          %% a period. If the arguments is `none', we only output the
-          %% attribute name, without following parentheses.
-          Ctxt1 = reset_prec(Ctxt),
-          Args = erl_syntax:attribute_arguments(Node),
-          N =
-              case erl_syntax:attribute_name(Node) of
-                {atom, _, 'if'} -> erl_syntax:variable('if');
-                N0 -> N0
-              end,
-          D =
-              case attribute_type(Node) of
-                spec ->
-                    [SpecTuple] = Args,
-                    [FuncName, FuncTypes] = erl_syntax:tuple_elements(SpecTuple),
-                    Name = get_func_node(FuncName),
-                    Types = dodge_macros(FuncTypes),
-                    D1 = lay_clauses(erl_syntax:concrete(Types), spec, Ctxt1),
-                    beside(follow(lay(N, Ctxt1), lay(Name, Ctxt1), Ctxt1#ctxt.break_indent), D1);
-                type ->
-                    [TypeTuple] = Args,
-                    [Name, Type0, Elements] = erl_syntax:tuple_elements(TypeTuple),
-                    TypeName = dodge_macros(Name),
-                    Type = dodge_macros(Type0),
-                    As0 = dodge_macros(Elements),
-                    As = erl_syntax:concrete(As0),
-                    D1 = lay_type_application(TypeName, As, Ctxt1),
-                    D2 = lay(erl_syntax:concrete(Type), Ctxt1),
-                    beside(follow(lay(N, Ctxt1),
-                                  beside(D1, lay_text_float(" :: ")),
-                                  Ctxt1#ctxt.break_indent),
-                           D2);
-                Tag when Tag =:= export_type; Tag =:= optional_callbacks ->
-                    [FuncNs] = Args,
-                    FuncNames = erl_syntax:concrete(dodge_macros(FuncNs)),
-                    As = unfold_function_names(FuncNames),
-                    beside(lay(N, Ctxt1),
-                           beside(text("("), beside(lay(As, Ctxt1), lay_text_float(")"))));
-                _ when Args =:= none -> lay(N, Ctxt1);
+        %% We list literals and other common cases first.
+        variable -> text(erl_syntax:variable_literal(Node));
+        atom -> text(erl_syntax:atom_literal(Node, Ctxt#ctxt.encoding));
+        integer -> text(tidy_integer(Node));
+        float -> text(tidy_float(Node));
+        char -> text(erl_syntax:char_literal(Node, Ctxt#ctxt.encoding));
+        string -> lay_string(erl_syntax:string_literal(Node, Ctxt#ctxt.encoding), Ctxt);
+        nil -> text("[]");
+        tuple ->
+            Es =
+                seq(erl_syntax:tuple_elements(Node),
+                    lay_text_float(","),
+                    reset_prec(Ctxt),
+                    fun lay/2),
+            beside(lay_text_float("{"), beside(sep(Es), lay_text_float("}")));
+        list ->
+            Ctxt1 = reset_prec(Ctxt),
+            Node1 = erl_syntax:compact_list(Node),
+            D1 = sep(seq(erl_syntax:list_prefix(Node1), lay_text_float(","), Ctxt1, fun lay/2)),
+            D =
+                case erl_syntax:list_suffix(Node1) of
+                    none -> beside(D1, lay_text_float("]"));
+                    S ->
+                        follow(D1,
+                               beside(lay_text_float("| "),
+                                      beside(lay(S, Ctxt1), lay_text_float("]"))))
+                end,
+            beside(lay_text_float("["), D);
+        operator -> lay_text_float(erl_syntax:operator_literal(Node));
+        infix_expr ->
+            Operator = erl_syntax:infix_expr_operator(Node),
+            {PrecL, Prec, PrecR} =
+                case erl_syntax:type(Operator) of
+                    operator -> inop_prec(erl_syntax:operator_name(Operator));
+                    _ -> {0, 0, 0}
+                end,
+            D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(Operator, reset_prec(Ctxt)),
+            D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
+            D4 = par([D1, D2, D3], Ctxt#ctxt.break_indent),
+            maybe_parentheses(D4, Prec, Ctxt);
+        prefix_expr ->
+            Operator = erl_syntax:prefix_expr_operator(Node),
+            {{Prec, PrecR}, Name} =
+                case erl_syntax:type(Operator) of
+                    operator ->
+                        N = erl_syntax:operator_name(Operator),
+                        {preop_prec(N), N};
+                    _ -> {{0, 0}, any}
+                end,
+            D1 = lay(Operator, reset_prec(Ctxt)),
+            D2 = lay(erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
+            D3 =
+                case Name of
+                    '+' -> beside(D1, D2);
+                    '-' -> beside(D1, D2);
+                    _ -> par([D1, D2], Ctxt#ctxt.break_indent)
+                end,
+            maybe_parentheses(D3, Prec, Ctxt);
+        application ->
+            {PrecL, Prec} = func_prec(),
+            D = lay(erl_syntax:application_operator(Node), set_prec(Ctxt, PrecL)),
+            As =
+                seq(erl_syntax:application_arguments(Node),
+                    floating(text(",")),
+                    reset_prec(Ctxt),
+                    fun lay/2),
+            D1 = beside(D, beside(text("("), beside(sep(As), floating(text(")"))))),
+            maybe_parentheses(D1, Prec, Ctxt);
+        match_expr ->
+            {PrecL, Prec, PrecR} = inop_prec('='),
+            D1 = lay(erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D3 = follow(beside(D1, lay_text_float(" =")), D2, Ctxt#ctxt.break_indent),
+            maybe_parentheses(D3, Prec, Ctxt);
+        underscore -> text("_");
+        clause ->
+            %% The style used for a clause depends on its context
+            Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
+            D1 = par(seq(erl_syntax:clause_patterns(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D2 =
+                case erl_syntax:clause_guard(Node) of
+                    none -> none;
+                    G -> lay(G, Ctxt1)
+                end,
+            D3 = lay_clause_expressions(erl_syntax:clause_body(Node), Ctxt1),
+            case Ctxt#ctxt.clause of
+                fun_expr -> make_fun_clause(D1, D2, D3, Ctxt);
+                {function, N} -> make_fun_clause(N, D1, D2, D3, Ctxt);
+                if_expr -> make_if_clause(D1, D2, D3, Ctxt);
+                case_expr -> make_case_clause(D1, D2, D3, Ctxt);
+                receive_expr -> make_case_clause(D1, D2, D3, Ctxt);
+                try_expr -> make_case_clause(D1, D2, D3, Ctxt);
+                undefined ->
+                    %% If a clause is formatted out of context, we
+                    %% use a "fun-expression" clause style.
+                    make_fun_clause(D1, D2, D3, Ctxt)
+            end;
+        function ->
+            %% Comments on the name itself will be repeated for each
+            %% clause, but that seems to be the best way to handle it.
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:function_name(Node), Ctxt1),
+            D2 = lay_clauses(erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
+            beside(D2, lay_text_float("."));
+        case_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:case_expr_argument(Node), Ctxt1),
+            D2 = lay_clauses(erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
+            sep([par([follow(text("case"), D1, Ctxt1#ctxt.break_indent), text("of")],
+                     Ctxt1#ctxt.break_indent),
+                 nest(Ctxt1#ctxt.break_indent, D2),
+                 text("end")]);
+        if_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
+            sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
+        fun_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
+            lay_fun_sep(Clauses, Ctxt1);
+        named_fun_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:named_fun_expr_name(Node), Ctxt1),
+            Clauses = lay_clauses(erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
+            lay_fun_sep(Clauses, Ctxt1);
+        module_qualifier ->
+            {PrecL, _Prec, PrecR} = inop_prec(':'),
+            D1 = lay(erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
+            beside(D1, beside(text(":"), D2));
+        %%
+        %% The rest is in alphabetical order (except map and types)
+        %%
+        arity_qualifier ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:arity_qualifier_body(Node), Ctxt1),
+            D2 = lay(erl_syntax:arity_qualifier_argument(Node), Ctxt1),
+            beside(D1, beside(text("/"), D2));
+        attribute ->
+            %% The attribute name and arguments are formatted similar to
+            %% a function call, but prefixed with a "-" and followed by
+            %% a period. If the arguments is `none', we only output the
+            %% attribute name, without following parentheses.
+            Ctxt1 = reset_prec(Ctxt),
+            Args = erl_syntax:attribute_arguments(Node),
+            N =
+                case erl_syntax:attribute_name(Node) of
+                    {atom, _, 'if'} -> erl_syntax:variable('if');
+                    N0 -> N0
+                end,
+            D =
+                case attribute_type(Node) of
+                    spec ->
+                        [SpecTuple] = Args,
+                        [FuncName, FuncTypes] = erl_syntax:tuple_elements(SpecTuple),
+                        Name = get_func_node(FuncName),
+                        Types = dodge_macros(FuncTypes),
+                        D1 = lay_clauses(erl_syntax:concrete(Types), spec, Ctxt1),
+                        beside(follow(lay(N, Ctxt1), lay(Name, Ctxt1), Ctxt1#ctxt.break_indent),
+                               D1);
+                    type ->
+                        [TypeTuple] = Args,
+                        [Name, Type0, Elements] = erl_syntax:tuple_elements(TypeTuple),
+                        TypeName = dodge_macros(Name),
+                        Type = dodge_macros(Type0),
+                        As0 = dodge_macros(Elements),
+                        As = erl_syntax:concrete(As0),
+                        D1 = lay_type_application(TypeName, As, Ctxt1),
+                        D2 = lay(erl_syntax:concrete(Type), Ctxt1),
+                        beside(follow(lay(N, Ctxt1),
+                                      beside(D1, lay_text_float(" :: ")),
+                                      Ctxt1#ctxt.break_indent),
+                               D2);
+                    Tag when Tag =:= export_type; Tag =:= optional_callbacks ->
+                        [FuncNs] = Args,
+                        FuncNames = erl_syntax:concrete(dodge_macros(FuncNs)),
+                        As = unfold_function_names(FuncNames),
+                        beside(lay(N, Ctxt1),
+                               beside(text("("), beside(lay(As, Ctxt1), lay_text_float(")"))));
+                    _ when Args =:= none -> lay(N, Ctxt1);
+                    _ ->
+                        D1 = sep(seq(Args, lay_text_float(","), Ctxt1, fun lay/2)),
+                        beside(lay(N, Ctxt1), beside(text("("), beside(D1, lay_text_float(")"))))
+                end,
+            beside(lay_text_float("-"), beside(D, lay_text_float(".")));
+        binary ->
+            Ctxt1 = reset_prec(Ctxt),
+            Es = seq(erl_syntax:binary_fields(Node), lay_text_float(","), Ctxt1, fun lay/2),
+            beside(lay_text_float("<<"), beside(par(Es), lay_text_float(">>")));
+        binary_field ->
+            Ctxt1 = set_prec(Ctxt, max_prec()),
+            D1 = lay(erl_syntax:binary_field_body(Node), Ctxt1),
+            D2 =
+                case erl_syntax:binary_field_types(Node) of
+                    [] -> empty();
+                    Ts -> beside(lay_text_float("/"), lay_bit_types(Ts, Ctxt1))
+                end,
+            beside(D1, D2);
+        block_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            Es = seq(erl_syntax:block_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2),
+            sep([text("begin"), nest(Ctxt1#ctxt.break_indent, sep(Es)), text("end")]);
+        catch_expr ->
+            {Prec, PrecR} = preop_prec('catch'),
+            D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D1 = follow(text("catch"), D, Ctxt#ctxt.break_indent),
+            maybe_parentheses(D1, Prec, Ctxt);
+        class_qualifier ->
+            Ctxt1 = set_prec(Ctxt, max_prec()),
+            D1 = lay(erl_syntax:class_qualifier_argument(Node), Ctxt1),
+            D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
+            Stacktrace = erl_syntax:class_qualifier_stacktrace(Node),
+            case erl_syntax:variable_name(Stacktrace) of
+                '_' -> beside(D1, beside(text(":"), D2));
                 _ ->
-                    D1 = sep(seq(Args, lay_text_float(","), Ctxt1, fun lay/2)),
-                    beside(lay(N, Ctxt1), beside(text("("), beside(D1, lay_text_float(")"))))
-              end,
-          beside(lay_text_float("-"), beside(D, lay_text_float(".")));
-      binary ->
-          Ctxt1 = reset_prec(Ctxt),
-          Es = seq(erl_syntax:binary_fields(Node), lay_text_float(","), Ctxt1, fun lay/2),
-          beside(lay_text_float("<<"), beside(par(Es), lay_text_float(">>")));
-      binary_field ->
-          Ctxt1 = set_prec(Ctxt, max_prec()),
-          D1 = lay(erl_syntax:binary_field_body(Node), Ctxt1),
-          D2 =
-              case erl_syntax:binary_field_types(Node) of
-                [] -> empty();
-                Ts -> beside(lay_text_float("/"), lay_bit_types(Ts, Ctxt1))
-              end,
-          beside(D1, D2);
-      block_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          Es = seq(erl_syntax:block_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2),
-          sep([text("begin"), nest(Ctxt1#ctxt.break_indent, sep(Es)), text("end")]);
-      catch_expr ->
-          {Prec, PrecR} = preop_prec('catch'),
-          D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
-          D1 = follow(text("catch"), D, Ctxt#ctxt.break_indent),
-          maybe_parentheses(D1, Prec, Ctxt);
-      class_qualifier ->
-          Ctxt1 = set_prec(Ctxt, max_prec()),
-          D1 = lay(erl_syntax:class_qualifier_argument(Node), Ctxt1),
-          D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
-          Stacktrace = erl_syntax:class_qualifier_stacktrace(Node),
-          case erl_syntax:variable_name(Stacktrace) of
-            '_' -> beside(D1, beside(text(":"), D2));
-            _ ->
-                D3 = lay(Stacktrace, Ctxt1),
-                beside(D1, beside(beside(text(":"), D2), beside(text(":"), D3)))
-          end;
-      comment ->
-          D = stack_comment_lines(erl_syntax:comment_text(Node)),
-          %% Default padding for standalone comments is empty.
-          case erl_syntax:comment_padding(Node) of
-            none -> floating(break(D));
-            P -> floating(break(beside(text(spaces(P)), D)))
-          end;
-      conjunction ->
-          par(seq(erl_syntax:conjunction_body(Node),
-                  lay_text_float(","),
-                  reset_prec(Ctxt),
-                  fun lay/2));
-      disjunction ->
-          %% For clarity, we don't paragraph-format
-          %% disjunctions; only conjunctions (see above).
-          sep(seq(erl_syntax:disjunction_body(Node),
-                  lay_text_float(";"),
-                  reset_prec(Ctxt),
-                  fun lay/2));
-      error_marker ->
-          E = erl_syntax:error_marker_info(Node),
-          beside(text("** "), beside(lay_error_info(E, reset_prec(Ctxt)), text(" **")));
-      eof_marker -> empty();
-      form_list ->
-          Es = seq(erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
-          vertical_sep(text(""), Es);
-      generator ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:generator_pattern(Node), Ctxt1),
-          D2 = lay(erl_syntax:generator_body(Node), Ctxt1),
-          par([D1, beside(text("<- "), D2)], Ctxt1#ctxt.break_indent);
-      binary_generator ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
-          D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
-          par([D1, beside(text("<= "), D2)], Ctxt1#ctxt.break_indent);
-      implicit_fun ->
-          D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
-          beside(lay_text_float("fun "), D);
-      list_comp ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:list_comp_template(Node), Ctxt1),
-          D2 = par(seq(erl_syntax:list_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          beside(lay_text_float("["),
-                 par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float("]")))]));
-      binary_comp ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:binary_comp_template(Node), Ctxt1),
-          D2 = par(seq(erl_syntax:binary_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          beside(lay_text_float("<< "),
-                 par([D1, beside(lay_text_float(" || "), beside(D2, lay_text_float(" >>")))]));
-      macro ->
-          %% This is formatted similar to a normal function call, but
-          %% prefixed with a "?".
-          Ctxt1 = reset_prec(Ctxt),
-          N = erl_syntax:macro_name(Node),
-          D =
-              case erl_syntax:macro_arguments(Node) of
-                none -> lay(N, Ctxt1);
-                Args ->
-                    As = seq(Args, lay_text_float(","), set_prec(Ctxt1, max_prec()), fun lay/2),
-                    beside(lay(N, Ctxt1), beside(text("("), beside(par(As), lay_text_float(")"))))
-              end,
-          D1 = beside(lay_text_float("?"), D),
-          maybe_parentheses(D1,
-                            0,
-                            Ctxt);    % must be conservative!
-      parentheses ->
-          D = lay(erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
-          lay_parentheses(D, Ctxt);
-      receive_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay_clauses(erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
-          D2 =
-              case erl_syntax:receive_expr_timeout(Node) of
+                    D3 = lay(Stacktrace, Ctxt1),
+                    beside(D1, beside(beside(text(":"), D2), beside(text(":"), D3)))
+            end;
+        comment ->
+            D = stack_comment_lines(erl_syntax:comment_text(Node)),
+            %% Default padding for standalone comments is empty.
+            case erl_syntax:comment_padding(Node) of
+                none -> floating(break(D));
+                P -> floating(break(beside(text(spaces(P)), D)))
+            end;
+        conjunction ->
+            par(seq(erl_syntax:conjunction_body(Node),
+                    lay_text_float(","),
+                    reset_prec(Ctxt),
+                    fun lay/2));
+        disjunction ->
+            %% For clarity, we don't paragraph-format
+            %% disjunctions; only conjunctions (see above).
+            sep(seq(erl_syntax:disjunction_body(Node),
+                    lay_text_float(";"),
+                    reset_prec(Ctxt),
+                    fun lay/2));
+        error_marker ->
+            E = erl_syntax:error_marker_info(Node),
+            beside(text("** "), beside(lay_error_info(E, reset_prec(Ctxt)), text(" **")));
+        eof_marker -> empty();
+        form_list ->
+            Es = seq(erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
+            vertical_sep(text(""), Es);
+        generator ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:generator_pattern(Node), Ctxt1),
+            D2 = lay(erl_syntax:generator_body(Node), Ctxt1),
+            par([D1, beside(text("<- "), D2)], Ctxt1#ctxt.break_indent);
+        binary_generator ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
+            D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
+            par([D1, beside(text("<= "), D2)], Ctxt1#ctxt.break_indent);
+        implicit_fun ->
+            D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
+            beside(lay_text_float("fun "), D);
+        list_comp ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:list_comp_template(Node), Ctxt1),
+            D2 = par(seq(erl_syntax:list_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            beside(lay_text_float("["),
+                   par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float("]")))]));
+        binary_comp ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:binary_comp_template(Node), Ctxt1),
+            D2 = par(seq(erl_syntax:binary_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            beside(lay_text_float("<< "),
+                   par([D1, beside(lay_text_float(" || "), beside(D2, lay_text_float(" >>")))]));
+        macro ->
+            %% This is formatted similar to a normal function call, but
+            %% prefixed with a "?".
+            Ctxt1 = reset_prec(Ctxt),
+            N = erl_syntax:macro_name(Node),
+            D =
+                case erl_syntax:macro_arguments(Node) of
+                    none -> lay(N, Ctxt1);
+                    Args ->
+                        As = seq(Args, lay_text_float(","), set_prec(Ctxt1, max_prec()), fun lay/2),
+                        beside(lay(N, Ctxt1),
+                               beside(text("("), beside(par(As), lay_text_float(")"))))
+                end,
+            D1 = beside(lay_text_float("?"), D),
+            maybe_parentheses(D1,
+                              0,
+                              Ctxt);    % must be conservative!
+        parentheses ->
+            D = lay(erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
+            lay_parentheses(D, Ctxt);
+        receive_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay_clauses(erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
+            D2 =
+                case erl_syntax:receive_expr_timeout(Node) of
+                    none -> D1;
+                    T ->
+                        D3 = lay(T, Ctxt1),
+                        A = erl_syntax:receive_expr_action(Node),
+                        D4 = sep(seq(A, lay_text_float(","), Ctxt1, fun lay/2)),
+                        sep([D1,
+                             follow(lay_text_float("after"),
+                                    append_clause_body(D4, D3, Ctxt1),
+                                    Ctxt1#ctxt.break_indent)])
+                end,
+            sep([text("receive"), nest(Ctxt1#ctxt.break_indent, D2), text("end")]);
+        record_access ->
+            {PrecL, Prec, PrecR} = inop_prec('#'),
+            D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                beside(lay_text_float("."),
+                       lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
+            T = erl_syntax:record_access_type(Node),
+            D3 = beside(beside(lay_text_float("#"), lay(T, reset_prec(Ctxt))), D2),
+            maybe_parentheses(beside(D1, D3), Prec, Ctxt);
+        record_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
+            D2 =
+                par(seq(erl_syntax:record_expr_fields(Node),
+                        lay_text_float(","),
+                        Ctxt1,
+                        fun lay/2)),
+            D3 =
+                beside(beside(lay_text_float("#"), D1),
+                       beside(text("{"), beside(D2, lay_text_float("}")))),
+            Arg = erl_syntax:record_expr_argument(Node),
+            lay_expr_argument(Arg, D3, Ctxt);
+        record_field ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:record_field_name(Node), Ctxt1),
+            case erl_syntax:record_field_value(Node) of
                 none -> D1;
-                T ->
-                    D3 = lay(T, Ctxt1),
-                    A = erl_syntax:receive_expr_action(Node),
-                    D4 = sep(seq(A, lay_text_float(","), Ctxt1, fun lay/2)),
-                    sep([D1,
-                         follow(lay_text_float("after"),
-                                append_clause_body(D4, D3, Ctxt1),
-                                Ctxt1#ctxt.break_indent)])
-              end,
-          sep([text("receive"), nest(Ctxt1#ctxt.break_indent, D2), text("end")]);
-      record_access ->
-          {PrecL, Prec, PrecR} = inop_prec('#'),
-          D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
-          D2 =
-              beside(lay_text_float("."),
-                     lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
-          T = erl_syntax:record_access_type(Node),
-          D3 = beside(beside(lay_text_float("#"), lay(T, reset_prec(Ctxt))), D2),
-          maybe_parentheses(beside(D1, D3), Prec, Ctxt);
-      record_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
-          D2 = par(seq(erl_syntax:record_expr_fields(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          D3 =
-              beside(beside(lay_text_float("#"), D1),
-                     beside(text("{"), beside(D2, lay_text_float("}")))),
-          Arg = erl_syntax:record_expr_argument(Node),
-          lay_expr_argument(Arg, D3, Ctxt);
-      record_field ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:record_field_name(Node), Ctxt1),
-          case erl_syntax:record_field_value(Node) of
-            none -> D1;
-            V -> par([D1, lay_text_float("="), lay(V, Ctxt1)], Ctxt1#ctxt.break_indent)
-          end;
-      record_index_expr ->
-          {Prec, PrecR} = preop_prec('#'),
-          D1 = lay(erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
-          D2 = lay(erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
-          D3 = beside(beside(lay_text_float("#"), D1), beside(lay_text_float("."), D2)),
-          maybe_parentheses(D3, Prec, Ctxt);
-      map_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = par(seq(erl_syntax:map_expr_fields(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          D2 = beside(text("#{"), beside(D1, lay_text_float("}"))),
-          Arg = erl_syntax:map_expr_argument(Node),
-          lay_expr_argument(Arg, D2, Ctxt);
-      map_field_assoc ->
-          Name = erl_syntax:map_field_assoc_name(Node),
-          Value = erl_syntax:map_field_assoc_value(Node),
-          lay_type_assoc(Name, Value, Ctxt);
-      map_field_exact ->
-          Name = erl_syntax:map_field_exact_name(Node),
-          Value = erl_syntax:map_field_exact_value(Node),
-          lay_type_exact(Name, Value, Ctxt);
-      size_qualifier ->
-          Ctxt1 = set_prec(Ctxt, max_prec()),
-          D1 = lay(erl_syntax:size_qualifier_body(Node), Ctxt1),
-          D2 = lay(erl_syntax:size_qualifier_argument(Node), Ctxt1),
-          beside(D1, beside(text(":"), D2));
-      text -> text(erl_syntax:text_string(Node));
-      typed_record_field ->
-          {_, Prec, _} = type_inop_prec('::'),
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:typed_record_field_body(Node), Ctxt1),
-          D2 = lay(erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
-          D3 = par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent),
-          maybe_parentheses(D3, Prec, Ctxt);
-      try_expr ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = sep(seq(erl_syntax:try_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
-          Es0 = [text("end")],
-          Es1 =
-              case erl_syntax:try_expr_after(Node) of
-                [] -> Es0;
-                As ->
-                    D2 = sep(seq(As, lay_text_float(","), Ctxt1, fun lay/2)),
-                    [text("after"), nest(Ctxt1#ctxt.break_indent, D2) | Es0]
-              end,
-          Es2 =
-              case erl_syntax:try_expr_handlers(Node) of
-                [] -> Es1;
-                Hs ->
-                    D3 = lay_clauses(Hs, try_expr, Ctxt1),
-                    [text("catch"), nest(Ctxt1#ctxt.break_indent, D3) | Es1]
-              end,
-          Es3 =
-              case erl_syntax:try_expr_clauses(Node) of
-                [] -> Es2;
-                Cs ->
-                    D4 = lay_clauses(Cs, try_expr, Ctxt1),
-                    [text("of"), nest(Ctxt1#ctxt.break_indent, D4) | Es2]
-              end,
-          sep([par([follow(text("try"), D1, Ctxt1#ctxt.break_indent), hd(Es3)]) | tl(Es3)]);
-      warning_marker ->
-          E = erl_syntax:warning_marker_info(Node),
-          beside(text("%% WARNING: "), lay_error_info(E, reset_prec(Ctxt)));
-      %%
-      %% Types
-      %%
-      annotated_type ->
-          {_, Prec, _} = type_inop_prec('::'),
-          D1 = lay(erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
-          D2 = lay(erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
-          D3 = lay_follow_beside_text_float(D1, D2, Ctxt),
-          maybe_parentheses(D3, Prec, Ctxt);
-      type_application ->
-          Name = erl_syntax:type_application_name(Node),
-          Arguments = erl_syntax:type_application_arguments(Node),
-          %% Prefer shorthand notation.
-          case erl_syntax_lib:analyze_type_application(Node) of
-            {nil, 0} -> text("[]");
-            {list, 1} ->
-                [A] = Arguments,
-                D1 = lay(A, reset_prec(Ctxt)),
-                beside(text("["), beside(D1, text("]")));
-            {nonempty_list, 1} ->
-                [A] = Arguments,
-                D1 = lay(A, reset_prec(Ctxt)),
-                beside(text("["), beside(D1, text(", ...]")));
-            _ -> lay_type_application(Name, Arguments, Ctxt)
-          end;
-      bitstring_type ->
-          Ctxt1 = set_prec(Ctxt, max_prec()),
-          M = erl_syntax:bitstring_type_m(Node),
-          N = erl_syntax:bitstring_type_n(Node),
-          D1 =
-              [beside(text("_:"), lay(M, Ctxt1))
-               || erl_syntax:type(M) =/= integer orelse erl_syntax:integer_value(M) =/= 0],
-          D2 =
-              [beside(text("_:_*"), lay(N, Ctxt1))
-               || erl_syntax:type(N) =/= integer orelse erl_syntax:integer_value(N) =/= 0],
-          F = fun (D, _) -> D end,
-          D = seq(D1 ++ D2, lay_text_float(","), Ctxt1, F),
-          beside(lay_text_float("<<"), beside(par(D), lay_text_float(">>")));
-      fun_type -> text("fun()");
-      constrained_function_type ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:constrained_function_type_body(Node), Ctxt1),
-          Ctxt2 = Ctxt1#ctxt{clause = undefined},
-          D2 = lay(erl_syntax:constrained_function_type_argument(Node), Ctxt2),
-          beside(D1, beside(lay_text_float(" when "), D2));
-      function_type ->
-          {Before, After} =
-              case Ctxt#ctxt.clause of
-                spec -> {"", ""};
-                _ -> {"fun(", ")"}
-              end,
-          Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
-          D1 =
-              case erl_syntax:function_type_arguments(Node) of
-                any_arity -> text("(...)");
-                Arguments ->
-                    As = seq(Arguments, lay_text_float(","), Ctxt1, fun lay/2),
-                    beside(text("("), beside(par(As), lay_text_float(")")))
-              end,
-          D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
-          beside(lay_text_float(Before),
-                 beside(D1, beside(lay_text_float(" -> "), beside(D2, lay_text_float(After)))));
-      constraint ->
-          Name = erl_syntax:constraint_argument(Node),
-          Args = erl_syntax:constraint_body(Node),
-          case is_subtype(Name, Args) of
-            true ->
-                [Var, Type] = Args,
-                {PrecL, Prec, PrecR} = type_inop_prec('::'),
-                D1 = lay(Var, set_prec(Ctxt, PrecL)),
-                D2 = lay(Type, set_prec(Ctxt, PrecR)),
-                D3 = lay_follow_beside_text_float(D1, D2, Ctxt),
-                maybe_parentheses(D3, Prec, Ctxt);
-            false -> lay_type_application(Name, Args, Ctxt)
-          end;
-      map_type ->
-          case erl_syntax:map_type_fields(Node) of
-            any_size -> text("map()");
-            Fs ->
-                Ctxt1 = reset_prec(Ctxt),
-                Es = seq(Fs, lay_text_float(","), Ctxt1, fun lay/2),
-                D = beside(lay_text_float("#{"), beside(par(Es), lay_text_float("}"))),
-                {Prec, _PrecR} = type_preop_prec('#'),
-                maybe_parentheses(D, Prec, Ctxt)
-          end;
-      map_type_assoc ->
-          Name = erl_syntax:map_type_assoc_name(Node),
-          Value = erl_syntax:map_type_assoc_value(Node),
-          lay_type_assoc(Name, Value, Ctxt);
-      map_type_exact ->
-          Name = erl_syntax:map_type_exact_name(Node),
-          Value = erl_syntax:map_type_exact_value(Node),
-          lay_type_exact(Name, Value, Ctxt);
-      integer_range_type ->
-          {PrecL, Prec, PrecR} = type_inop_prec('..'),
-          D1 = lay(erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
-          D2 = lay(erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
-          D3 = beside(D1, beside(text(".."), D2)),
-          maybe_parentheses(D3, Prec, Ctxt);
-      record_type ->
-          {Prec, _PrecR} = type_preop_prec('#'),
-          D1 = beside(text("#"), lay(erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
-          Es =
-              seq(erl_syntax:record_type_fields(Node),
-                  lay_text_float(","),
-                  reset_prec(Ctxt),
-                  fun lay/2),
-          D2 = beside(D1, beside(text("{"), beside(par(Es), lay_text_float("}")))),
-          maybe_parentheses(D2, Prec, Ctxt);
-      record_type_field ->
-          Ctxt1 = reset_prec(Ctxt),
-          D1 = lay(erl_syntax:record_type_field_name(Node), Ctxt1),
-          D2 = lay(erl_syntax:record_type_field_type(Node), Ctxt1),
-          par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent);
-      tuple_type ->
-          case erl_syntax:tuple_type_elements(Node) of
-            any_size -> text("tuple()");
-            Elements ->
-                Es = seq(Elements, lay_text_float(","), reset_prec(Ctxt), fun lay/2),
-                beside(lay_text_float("{"), beside(par(Es), lay_text_float("}")))
-          end;
-      type_union ->
-          {_, Prec, PrecR} = type_inop_prec('|'),
-          Es =
-              sep(seq(erl_syntax:type_union_types(Node),
-                      lay_text_float(" |"),
-                      set_prec(Ctxt, PrecR),
-                      fun lay/2)),
-          maybe_parentheses(Es, Prec, Ctxt);
-      user_type_application ->
-          lay_type_application(erl_syntax:user_type_application_name(Node),
-                               erl_syntax:user_type_application_arguments(Node),
-                               Ctxt)
+                V -> par([D1, lay_text_float("="), lay(V, Ctxt1)], Ctxt1#ctxt.break_indent)
+            end;
+        record_index_expr ->
+            {Prec, PrecR} = preop_prec('#'),
+            D1 = lay(erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
+            D2 = lay(erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
+            D3 = beside(beside(lay_text_float("#"), D1), beside(lay_text_float("."), D2)),
+            maybe_parentheses(D3, Prec, Ctxt);
+        map_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = par(seq(erl_syntax:map_expr_fields(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D2 = beside(text("#{"), beside(D1, lay_text_float("}"))),
+            Arg = erl_syntax:map_expr_argument(Node),
+            lay_expr_argument(Arg, D2, Ctxt);
+        map_field_assoc ->
+            Name = erl_syntax:map_field_assoc_name(Node),
+            Value = erl_syntax:map_field_assoc_value(Node),
+            lay_type_assoc(Name, Value, Ctxt);
+        map_field_exact ->
+            Name = erl_syntax:map_field_exact_name(Node),
+            Value = erl_syntax:map_field_exact_value(Node),
+            lay_type_exact(Name, Value, Ctxt);
+        size_qualifier ->
+            Ctxt1 = set_prec(Ctxt, max_prec()),
+            D1 = lay(erl_syntax:size_qualifier_body(Node), Ctxt1),
+            D2 = lay(erl_syntax:size_qualifier_argument(Node), Ctxt1),
+            beside(D1, beside(text(":"), D2));
+        text -> text(erl_syntax:text_string(Node));
+        typed_record_field ->
+            {_, Prec, _} = type_inop_prec('::'),
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:typed_record_field_body(Node), Ctxt1),
+            D2 = lay(erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
+            D3 = par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent),
+            maybe_parentheses(D3, Prec, Ctxt);
+        try_expr ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = sep(seq(erl_syntax:try_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            Es0 = [text("end")],
+            Es1 =
+                case erl_syntax:try_expr_after(Node) of
+                    [] -> Es0;
+                    As ->
+                        D2 = sep(seq(As, lay_text_float(","), Ctxt1, fun lay/2)),
+                        [text("after"), nest(Ctxt1#ctxt.break_indent, D2) | Es0]
+                end,
+            Es2 =
+                case erl_syntax:try_expr_handlers(Node) of
+                    [] -> Es1;
+                    Hs ->
+                        D3 = lay_clauses(Hs, try_expr, Ctxt1),
+                        [text("catch"), nest(Ctxt1#ctxt.break_indent, D3) | Es1]
+                end,
+            Es3 =
+                case erl_syntax:try_expr_clauses(Node) of
+                    [] -> Es2;
+                    Cs ->
+                        D4 = lay_clauses(Cs, try_expr, Ctxt1),
+                        [text("of"), nest(Ctxt1#ctxt.break_indent, D4) | Es2]
+                end,
+            sep([par([follow(text("try"), D1, Ctxt1#ctxt.break_indent), hd(Es3)]) | tl(Es3)]);
+        warning_marker ->
+            E = erl_syntax:warning_marker_info(Node),
+            beside(text("%% WARNING: "), lay_error_info(E, reset_prec(Ctxt)));
+        %%
+        %% Types
+        %%
+        annotated_type ->
+            {_, Prec, _} = type_inop_prec('::'),
+            D1 = lay(erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
+            D2 = lay(erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
+            D3 = lay_follow_beside_text_float(D1, D2, Ctxt),
+            maybe_parentheses(D3, Prec, Ctxt);
+        type_application ->
+            Name = erl_syntax:type_application_name(Node),
+            Arguments = erl_syntax:type_application_arguments(Node),
+            %% Prefer shorthand notation.
+            case erl_syntax_lib:analyze_type_application(Node) of
+                {nil, 0} -> text("[]");
+                {list, 1} ->
+                    [A] = Arguments,
+                    D1 = lay(A, reset_prec(Ctxt)),
+                    beside(text("["), beside(D1, text("]")));
+                {nonempty_list, 1} ->
+                    [A] = Arguments,
+                    D1 = lay(A, reset_prec(Ctxt)),
+                    beside(text("["), beside(D1, text(", ...]")));
+                _ -> lay_type_application(Name, Arguments, Ctxt)
+            end;
+        bitstring_type ->
+            Ctxt1 = set_prec(Ctxt, max_prec()),
+            M = erl_syntax:bitstring_type_m(Node),
+            N = erl_syntax:bitstring_type_n(Node),
+            D1 =
+                [beside(text("_:"), lay(M, Ctxt1))
+                 || erl_syntax:type(M) =/= integer orelse erl_syntax:integer_value(M) =/= 0],
+            D2 =
+                [beside(text("_:_*"), lay(N, Ctxt1))
+                 || erl_syntax:type(N) =/= integer orelse erl_syntax:integer_value(N) =/= 0],
+            F = fun (D, _) -> D end,
+            D = seq(D1 ++ D2, lay_text_float(","), Ctxt1, F),
+            beside(lay_text_float("<<"), beside(par(D), lay_text_float(">>")));
+        fun_type -> text("fun()");
+        constrained_function_type ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:constrained_function_type_body(Node), Ctxt1),
+            Ctxt2 = Ctxt1#ctxt{clause = undefined},
+            D2 = lay(erl_syntax:constrained_function_type_argument(Node), Ctxt2),
+            beside(D1, beside(lay_text_float(" when "), D2));
+        function_type ->
+            {Before, After} =
+                case Ctxt#ctxt.clause of
+                    spec -> {"", ""};
+                    _ -> {"fun(", ")"}
+                end,
+            Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
+            D1 =
+                case erl_syntax:function_type_arguments(Node) of
+                    any_arity -> text("(...)");
+                    Arguments ->
+                        As = seq(Arguments, lay_text_float(","), Ctxt1, fun lay/2),
+                        beside(text("("), beside(par(As), lay_text_float(")")))
+                end,
+            D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
+            beside(lay_text_float(Before),
+                   beside(D1, beside(lay_text_float(" -> "), beside(D2, lay_text_float(After)))));
+        constraint ->
+            Name = erl_syntax:constraint_argument(Node),
+            Args = erl_syntax:constraint_body(Node),
+            case is_subtype(Name, Args) of
+                true ->
+                    [Var, Type] = Args,
+                    {PrecL, Prec, PrecR} = type_inop_prec('::'),
+                    D1 = lay(Var, set_prec(Ctxt, PrecL)),
+                    D2 = lay(Type, set_prec(Ctxt, PrecR)),
+                    D3 = lay_follow_beside_text_float(D1, D2, Ctxt),
+                    maybe_parentheses(D3, Prec, Ctxt);
+                false -> lay_type_application(Name, Args, Ctxt)
+            end;
+        map_type ->
+            case erl_syntax:map_type_fields(Node) of
+                any_size -> text("map()");
+                Fs ->
+                    Ctxt1 = reset_prec(Ctxt),
+                    Es = seq(Fs, lay_text_float(","), Ctxt1, fun lay/2),
+                    D = beside(lay_text_float("#{"), beside(par(Es), lay_text_float("}"))),
+                    {Prec, _PrecR} = type_preop_prec('#'),
+                    maybe_parentheses(D, Prec, Ctxt)
+            end;
+        map_type_assoc ->
+            Name = erl_syntax:map_type_assoc_name(Node),
+            Value = erl_syntax:map_type_assoc_value(Node),
+            lay_type_assoc(Name, Value, Ctxt);
+        map_type_exact ->
+            Name = erl_syntax:map_type_exact_name(Node),
+            Value = erl_syntax:map_type_exact_value(Node),
+            lay_type_exact(Name, Value, Ctxt);
+        integer_range_type ->
+            {PrecL, Prec, PrecR} = type_inop_prec('..'),
+            D1 = lay(erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
+            D3 = beside(D1, beside(text(".."), D2)),
+            maybe_parentheses(D3, Prec, Ctxt);
+        record_type ->
+            {Prec, _PrecR} = type_preop_prec('#'),
+            D1 = beside(text("#"), lay(erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
+            Es =
+                seq(erl_syntax:record_type_fields(Node),
+                    lay_text_float(","),
+                    reset_prec(Ctxt),
+                    fun lay/2),
+            D2 = beside(D1, beside(text("{"), beside(par(Es), lay_text_float("}")))),
+            maybe_parentheses(D2, Prec, Ctxt);
+        record_type_field ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:record_type_field_name(Node), Ctxt1),
+            D2 = lay(erl_syntax:record_type_field_type(Node), Ctxt1),
+            par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent);
+        tuple_type ->
+            case erl_syntax:tuple_type_elements(Node) of
+                any_size -> text("tuple()");
+                Elements ->
+                    Es = seq(Elements, lay_text_float(","), reset_prec(Ctxt), fun lay/2),
+                    beside(lay_text_float("{"), beside(par(Es), lay_text_float("}")))
+            end;
+        type_union ->
+            {_, Prec, PrecR} = type_inop_prec('|'),
+            Es =
+                sep(seq(erl_syntax:type_union_types(Node),
+                        lay_text_float(" |"),
+                        set_prec(Ctxt, PrecR),
+                        fun lay/2)),
+            maybe_parentheses(Es, Prec, Ctxt);
+        user_type_application ->
+            lay_type_application(erl_syntax:user_type_application_name(Node),
+                                 erl_syntax:user_type_application_arguments(Node),
+                                 Ctxt)
     end.
 
 attribute_type(Node) ->
     N = erl_syntax:attribute_name(Node),
     case catch erl_syntax:concrete(N) of
-      opaque -> type;
-      spec -> spec;
-      callback -> spec;
-      type -> type;
-      export_type -> export_type;
-      optional_callbacks -> optional_callbacks;
-      _ -> N
+        opaque -> type;
+        spec -> spec;
+        callback -> spec;
+        type -> type;
+        export_type -> export_type;
+        optional_callbacks -> optional_callbacks;
+        _ -> N
     end.
 
 is_subtype(Name, [Var, _]) ->
@@ -959,13 +966,13 @@ is_subtype(_, _) -> false.
 
 get_func_node(Node) ->
     case erl_syntax:type(Node) of
-      tuple ->
-          case erl_syntax:tuple_elements(Node) of
-            [F0, _] -> F0;
-            [M0, F0, _] -> erl_syntax:module_qualifier(M0, F0);
-            _ -> Node
-          end;
-      _ -> Node
+        tuple ->
+            case erl_syntax:tuple_elements(Node) of
+                [F0, _] -> F0;
+                [M0, F0, _] -> erl_syntax:module_qualifier(M0, F0);
+                _ -> Node
+            end;
+        _ -> Node
     end.
 
 unfold_function_names(Ns) ->
@@ -980,13 +987,13 @@ dodge_macros(Type) ->
     F =
         fun (T) ->
                 case erl_syntax:type(T) of
-                  macro ->
-                      Var = erl_syntax:macro_name(T),
-                      VarName0 = erl_syntax:variable_name(Var),
-                      VarName = list_to_atom("?" ++ atom_to_list(VarName0)),
-                      Atom = erl_syntax:atom(VarName),
-                      Atom;
-                  _ -> T
+                    macro ->
+                        Var = erl_syntax:macro_name(T),
+                        VarName0 = erl_syntax:variable_name(Var),
+                        VarName = list_to_atom("?" ++ atom_to_list(VarName0)),
+                        Atom = erl_syntax:atom(VarName),
+                        Atom;
+                    _ -> T
                 end
         end,
     erl_syntax_lib:map(F, Type).
@@ -1011,8 +1018,8 @@ lay_parentheses(D, _Ctxt) -> beside(lay_text_float("("), beside(D, lay_text_floa
 
 maybe_parentheses(D, Prec, Ctxt) ->
     case Ctxt#ctxt.prec of
-      P when P > Prec -> lay_parentheses(D, Ctxt);
-      _ -> D
+        P when P > Prec -> lay_parentheses(D, Ctxt);
+        _ -> D
     end.
 
 lay_string(S, Ctxt) ->
@@ -1024,10 +1031,10 @@ lay_string(S, Ctxt) ->
 lay_string(S, L, W) when L > W, W > 0 ->
     %% Note that L is the minimum, not the exact, printed length.
     case split_string(S, W - 1, L) of
-      {_S1, ""} -> text(S);
-      {S1, S2} ->
-          above(text(S1 ++ "\""),
-                lay_string([$" | S2], L - W + 1, W))  %" stupid emacs
+        {_S1, ""} -> text(S);
+        {S1, S2} ->
+            above(text(S1 ++ "\""),
+                  lay_string([$" | S2], L - W + 1, W))  %" stupid emacs
     end;
 lay_string(S, _L, _W) -> text(S).
 
@@ -1097,8 +1104,8 @@ make_if_clause(_P, G, B, Ctxt) ->
     %% We ignore the patterns; they should be empty anyway.
     G1 =
         case G of
-          none -> text("true");
-          _ -> G
+            none -> text("true");
+            _ -> G
         end,
     append_clause_body(B, G1, Ctxt).
 
@@ -1116,12 +1123,12 @@ lay_bit_types([T | Ts], Ctxt) ->
 
 lay_error_info({L, M, T} = T0, Ctxt) when is_integer(L), is_atom(M) ->
     case catch apply(M, format_error, [T]) of
-      S when is_list(S) ->
-          case L > 0 of
-            true -> beside(text(io_lib:format("~w: ", [L])), text(S));
-            _ -> text(S)
-          end;
-      _ -> lay_concrete(T0, Ctxt)
+        S when is_list(S) ->
+            case L > 0 of
+                true -> beside(text(io_lib:format("~w: ", [L])), text(S));
+                _ -> text(S)
+            end;
+        _ -> lay_concrete(T0, Ctxt)
     end;
 lay_error_info(T, Ctxt) -> lay_concrete(T, Ctxt).
 
@@ -1146,8 +1153,8 @@ lay_type_application(Name, Arguments, Ctxt) ->
 
 seq([H | T], Separator, Ctxt, Fun) ->
     case T of
-      [] -> [Fun(H, Ctxt)];
-      _ -> [maybe_append(Separator, Fun(H, Ctxt)) | seq(T, Separator, Ctxt, Fun)]
+        [] -> [Fun(H, Ctxt)];
+        _ -> [maybe_append(Separator, Fun(H, Ctxt)) | seq(T, Separator, Ctxt, Fun)]
     end;
 seq([], _, _, _) -> [empty()].
 
@@ -1176,12 +1183,12 @@ tidy_float(Node) ->
 %%      them into integers or "pretty printed" floats.
 tidy_number(Node, Default) ->
     case erl_syntax:get_pos(Node) of
-      L when is_list(L) ->
-          case proplists:get_value(text, L, undefined) of
-            undefined -> Default;
-            Text -> number_from_text(Text, Default)
-          end;
-      _ -> Default
+        L when is_list(L) ->
+            case proplists:get_value(text, L, undefined) of
+                undefined -> Default;
+                Text -> number_from_text(Text, Default)
+            end;
+        _ -> Default
     end.
 
 %% @doc This function covers the corner case when erl_parse:parse_form/1
@@ -1191,8 +1198,8 @@ tidy_number(Node, Default) ->
 %% NOTE: floats work as "integers" according to string:to_integer/1
 number_from_text(Text, Default) ->
     case string:to_integer(Text) of
-      {error, no_integer} -> Default;
-      {_, _} -> Text
+        {error, no_integer} -> Default;
+        {_, _} -> Text
     end.
 
 lay_clause_expressions([H], Ctxt) -> lay(H, Ctxt);
@@ -1200,23 +1207,23 @@ lay_clause_expressions([H | T], Ctxt) ->
     Clause = beside(lay(H, Ctxt), lay_text_float(",")),
     Next = lay_clause_expressions(T, Ctxt),
     case is_last_and_before_empty_line(H, T, Ctxt) of
-      true -> above(above(Clause, text("")), Next);
-      false -> above(Clause, Next)
+        true -> above(above(Clause, text("")), Next);
+        false -> above(Clause, Next)
     end;
 lay_clause_expressions([], _) -> empty().
 
 is_last_and_before_empty_line(H, [], #ctxt{empty_lines = EmptyLines}) ->
     try
-      sets:is_element(erl_syntax:get_pos(H) + 1, EmptyLines)
+        sets:is_element(erl_syntax:get_pos(H) + 1, EmptyLines)
     catch
-      error:badarith -> false
+        error:badarith -> false
     end;
 is_last_and_before_empty_line(H, [H2 | _], #ctxt{empty_lines = EmptyLines}) ->
     try
-      (erl_syntax:get_pos(H2) - erl_syntax:get_pos(H) >= 2) and
-        sets:is_element(erl_syntax:get_pos(H) + 1, EmptyLines)
+        (erl_syntax:get_pos(H2) - erl_syntax:get_pos(H) >= 2) and
+            sets:is_element(erl_syntax:get_pos(H) + 1, EmptyLines)
     catch
-      error:badarith -> false
+        error:badarith -> false
     end.
 
 %% =====================================================================

--- a/src/formatters/sr_formatter.erl
+++ b/src/formatters/sr_formatter.erl
@@ -32,26 +32,26 @@ format_file(File, #{opts := GlobalOpts}, OptionsMap) ->
     Opts = parse_opts(OptionsMap) ++ GlobalOpts,
     FileToFormat =
         case maps:get(output_dir, OptionsMap, current) of
-          current ->
-              File;
-          none ->
-              File;
-          OutputDir ->
-              copy_file(File, OutputDir)
+            current ->
+                File;
+            none ->
+                File;
+            OutputDir ->
+                copy_file(File, OutputDir)
         end,
     {ok, Code} = file:read_file(FileToFormat),
     case steamroller:format_file(iolist_to_binary(FileToFormat), Opts) of
-      ok ->
-          case file:read_file(FileToFormat) of
-            {ok, Code} ->
-                unchanged;
-            {ok, _} ->
-                changed
-          end;
-      {error, <<"Check failed", _/binary>>} ->
-          changed;
-      {error, Reason} ->
-          erlang:error(Reason)
+        ok ->
+            case file:read_file(FileToFormat) of
+                {ok, Code} ->
+                    unchanged;
+                {ok, _} ->
+                    changed
+            end;
+        {error, <<"Check failed", _/binary>>} ->
+            changed;
+        {error, Reason} ->
+            erlang:error(Reason)
     end.
 
 parse_opts(OptionsMap) ->

--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -19,42 +19,42 @@ format(File, Formatter, Opts) ->
     Formatted = format(File, AST, Formatter, Comments, Opts),
     Result =
         case Formatted of
-          Original ->
-              unchanged;
-          _ ->
-              changed
+            Original ->
+                unchanged;
+            _ ->
+                changed
         end,
     case maybe_save_file(maps:get(output_dir, Opts), File, Formatted) of
-      none ->
-          Result;
-      NewFile ->
-          case get_quick_ast(NewFile) of
-            QuickAST ->
-                Result;
-            _ ->
-                erlang:error({modified_ast, File, NewFile})
-          end
+        none ->
+            Result;
+        NewFile ->
+            case get_quick_ast(NewFile) of
+                QuickAST ->
+                    Result;
+                _ ->
+                    erlang:error({modified_ast, File, NewFile})
+            end
     end.
 
 get_ast(File) ->
     case ktn_dodger:parse_file(File, [{scan_opts, [text]}]) of
-      {ok, AST} ->
-          case [Error || {error, Error} <- AST] of
-            [] ->
-                AST;
-            [Error | _] ->
-                erlang:error({cant_parse, File, Error})
-          end;
-      {error, OpenError} ->
-          erlang:error({cant_parse, File, OpenError})
+        {ok, AST} ->
+            case [Error || {error, Error} <- AST] of
+                [] ->
+                    AST;
+                [Error | _] ->
+                    erlang:error({cant_parse, File, Error})
+            end;
+        {error, OpenError} ->
+            erlang:error({cant_parse, File, OpenError})
     end.
 
 get_quick_ast(File) ->
     case ktn_dodger:quick_parse_file(File) of
-      {ok, AST} ->
-          remove_line_numbers(AST);
-      {error, OpenError} ->
-          erlang:error({cant_parse, File, OpenError})
+        {ok, AST} ->
+            remove_line_numbers(AST);
+        {error, OpenError} ->
+            erlang:error({cant_parse, File, OpenError})
     end.
 
 %% @doc Removes line numbers from ASTs to allow for "semantic" comparison
@@ -81,10 +81,10 @@ empty_lines(File) ->
     {Res, _} =
         lists:foldl(fun (Line, {EmptyLines, N}) ->
                             case re:run(Line, NonEmptyLineRe) of
-                              {match, _} ->
-                                  {EmptyLines, N + 1};
-                              nomatch ->
-                                  {[N | EmptyLines], N + 1}
+                                {match, _} ->
+                                    {EmptyLines, N + 1};
+                                nomatch ->
+                                    {[N | EmptyLines], N + 1}
                             end
                     end,
                     {[], 1},
@@ -94,10 +94,10 @@ empty_lines(File) ->
 insert_last_line(Formatted) ->
     {ok, Re} = re:compile("[\n]+$"),
     case re:run(Formatted, Re) of
-      {match, _} ->
-          re:replace(Formatted, Re, "\n", [{return, binary}]);
-      nomatch ->
-          <<Formatted/binary, "\n">>
+        {match, _} ->
+            re:replace(Formatted, Re, "\n", [{return, binary}]);
+        nomatch ->
+            <<Formatted/binary, "\n">>
     end.
 
 maybe_save_file(none, _File, _Formatted) ->

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -41,11 +41,11 @@ do(State) ->
     Files = get_files(Args, State) -- IgnoredFiles,
     rebar_api:debug("Found ~p files: ~p", [length(Files), Files]),
     case format_files(Files, Formatter) of
-      ok ->
-          ignore(IgnoredFiles, Formatter),
-          {ok, State};
-      {error, Error} ->
-          {error, format_error(Error)}
+        ok ->
+            ignore(IgnoredFiles, Formatter),
+            {ok, State};
+        {error, Error} ->
+            {error, format_error(Error)}
     end.
 
 %% @private
@@ -64,26 +64,26 @@ format_error(Reason) ->
 -spec get_action(proplists:proplist()) -> format | verify.
 get_action(Args) ->
     case lists:keyfind(verify, 1, Args) of
-      {verify, true} ->
-          verify;
-      _ ->
-          format
+        {verify, true} ->
+            verify;
+        _ ->
+            format
     end.
 
 -spec get_files(proplists:proplist(), rebar_state:t()) -> [file:filename_all()].
 get_files(Args, State) ->
     Patterns =
         case lists:keyfind(files, 1, Args) of
-          {files, Wildcard} ->
-              [Wildcard];
-          false ->
-              FormatConfig = rebar_state:get(State, format, []),
-              case proplists:get_value(files, FormatConfig, undefined) of
-                undefined ->
-                    ["src/**/*.[he]rl"];
-                Wildcards ->
-                    Wildcards
-              end
+            {files, Wildcard} ->
+                [Wildcard];
+            false ->
+                FormatConfig = rebar_state:get(State, format, []),
+                case proplists:get_value(files, FormatConfig, undefined) of
+                    undefined ->
+                        ["src/**/*.[he]rl"];
+                    Wildcards ->
+                        Wildcards
+                end
         end,
     [File || Pattern <- Patterns, File <- filelib:wildcard(Pattern)].
 
@@ -97,12 +97,12 @@ get_ignored_files(State) ->
                         none | current | file:filename_all().
 get_output_dir(Action, Args) ->
     case {lists:keyfind(output, 1, Args), Action} of
-      {{output, OutputDir}, _} ->
-          OutputDir;
-      {false, format} ->
-          current;
-      {false, verify} ->
-          none
+        {{output, OutputDir}, _} ->
+            OutputDir;
+        {false, format} ->
+            current;
+        {false, verify} ->
+            none
     end.
 
 -spec get_formatter(rebar_state:t(), rebar3_formatter:opts()) -> rebar3_formatter:t().
@@ -123,22 +123,22 @@ format_files(Files, Formatter) ->
                      end,
                      Files)
     of
-      [] ->
-          ok;
-      ChangedFiles ->
-          case rebar3_formatter:action(Formatter) of
-            format ->
-                ok;
-            verify ->
-                {error, {unformatted_files, ChangedFiles}}
-          end
+        [] ->
+            ok;
+        ChangedFiles ->
+            case rebar3_formatter:action(Formatter) of
+                format ->
+                    ok;
+                verify ->
+                    {error, {unformatted_files, ChangedFiles}}
+            end
     catch
-      _:{cant_parse, File, {Line, erl_parse, Error}} ->
-          rebar_api:warn("Couldn't parse ~s:~p ~s", [File, Line, Error]),
-          {error, {erl_parse, File, Error}};
-      _:Error:Stack ->
-          rebar_api:warn("Error parsing files: ~p~nStack: ~p", [Error, Stack]),
-          {error, Error}
+        _:{cant_parse, File, {Line, erl_parse, Error}} ->
+            rebar_api:warn("Couldn't parse ~s:~p ~s", [File, Line, Error]),
+            {error, {erl_parse, File, Error}};
+        _:Error:Stack ->
+            rebar_api:warn("Error parsing files: ~p~nStack: ~p", [Error, Stack]),
+            {error, Error}
     end.
 
 %% @doc Process ignored files

--- a/src/rebar3_formatter.erl
+++ b/src/rebar3_formatter.erl
@@ -32,11 +32,11 @@ new(Module, Opts, RebarState) ->
 -spec format_file(file:filename_all(), t()) -> result().
 format_file(File, #{opts := Opts, module := Module, state := State} = Formatter) ->
     case apply_per_file_opts(File, Opts) of
-      ignore ->
-          ignore(File, Formatter),
-          unchanged;
-      FileOpts ->
-          Module:format_file(File, State, FileOpts)
+        ignore ->
+            ignore(File, Formatter),
+            unchanged;
+        FileOpts ->
+            Module:format_file(File, State, FileOpts)
     end.
 
 %% @doc Process an ignored file.
@@ -62,12 +62,12 @@ apply_per_file_opts(File, Opts) ->
     {ok, AST} = epp_dodger:quick_parse_file(File),
     FileOpts = [Opt || {attribute, _, format, Opt} <- AST],
     case lists:member(ignore, FileOpts) of
-      true ->
-          ignore;
-      false ->
-          MergeF =
-              fun (Map, Acc) ->
-                      maps:merge(Acc, Map)
-              end,
-          lists:foldl(MergeF, Opts, FileOpts)
+        true ->
+            ignore;
+        false ->
+            MergeF =
+                fun (Map, Acc) ->
+                        maps:merge(Acc, Map)
+                end,
+            lists:foldl(MergeF, Opts, FileOpts)
     end.

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -11,10 +11,10 @@ test_app(_Config) ->
     Files = {files, ["src/*.erl", "include/*.hrl"]},
     IgnoredFiles =
         case string:to_integer(erlang:system_info(otp_release)) of
-          {N, []} when N >= 23 ->
-              {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
-          _ ->
-              {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp23.erl"]}
+            {N, []} when N >= 23 ->
+                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
+            _ ->
+                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp23.erl"]}
         end,
     State2 = rebar_state:set(State1, format, [Files, IgnoredFiles]),
     {error, _} = verify(State2),
@@ -35,10 +35,10 @@ format(State) ->
 
 git_diff() ->
     case os:cmd("git --no-pager diff --no-index -- after formatted") of
-      "" ->
-          ok;
-      Diff ->
-          Unicode = unicode:characters_to_binary(Diff),
-          ct:pal("Differences:~n~s", [Unicode]),
-          ct:fail(Unicode)
+        "" ->
+            ok;
+        Diff ->
+            Unicode = unicode:characters_to_binary(Diff),
+            ct:pal("Differences:~n~s", [Unicode]),
+            ct:fail(Unicode)
     end.

--- a/test_app/after/src/break.erl
+++ b/test_app/after/src/break.erl
@@ -4,16 +4,16 @@
 
 break_on_receive() ->
     receive
-      {this, will, be, indented} ->
-          but_this:is(short)
-      after 1000 ->
-                this:too(should, go, below)
+        {this, will, be, indented} ->
+            but_this:is(short)
+        after 1000 ->
+                  this:too(should, go, below)
     end.
 
 break_on_try() ->
     try this:short(statement) of
-      {things, cant, be} ->
-          {a, <<"one-liner">>}
+        {things, cant, be} ->
+            {a, <<"one-liner">>}
     after
-      this:neither()
+        this:neither()
     end.

--- a/test_app/after/src/catch_test.erl
+++ b/test_app/after/src/catch_test.erl
@@ -2,21 +2,21 @@
 
 can_err(E) ->
     try E of
-      {A, B} ->
-          ok,
-          ok,
-          ok,
-          ok,
-          something_larger_than_ok
+        {A, B} ->
+            ok,
+            ok,
+            ok,
+            ok,
+            something_larger_than_ok
     catch
-      C:R:Stacktrace ->
-          error
+        C:R:Stacktrace ->
+            error
     end.
 
 also_can_err() ->
     try
-      launch_missiles
+        launch_missiles
     catch
-      E:R ->
-          error
+        E:R ->
+            error
     end.

--- a/test_app/after/src/igor_type_specs.erl
+++ b/test_app/after/src/igor_type_specs.erl
@@ -63,8 +63,8 @@ f({R, R}) ->
 -spec igor_type_specs:b() -> integer() | fun().
 b() ->
     case foo:bar() of
-      #{a := 2} ->
-          19
+        #{a := 2} ->
+            19
     end.
 
 -spec c(Atom :: atom(), Integer :: integer()) -> {atom(), integer()};

--- a/test_app/after/src/indent_1.erl
+++ b/test_app/after/src/indent_1.erl
@@ -1,9 +1,8 @@
--module(indent_18).
+-module(indent_1).
 
 -format #{break_indent => 1,
           inline_clause_bodies => true,
-          paper => 50,
-          sub_indent => 8}.
+          paper => 50}.
 
 -record(record,
         {fields =
@@ -17,8 +16,7 @@
 
 infix_expr() ->
  this:infix(expression) ++
-         should:be(indented) ++
-                 using:sub_indent(8).
+  should:be(indented) ++ using:indent(1).
 
 prefix_expr() ->
  ThisPrefixExpressionShould =
@@ -30,22 +28,18 @@ match_expr() ->
 
 case_expr() ->
  case expressions:that(are_too_long_for_a_line,
-                       should:be(indented_using:sub_indent(8)),
+                       should:be(indented_using:indent(1)),
                        but,
                        the,
                        "of",
                        should:be(indented_using:break_indent(1)))
   of
-         clauses ->
-          should:be(indented_using:sub_indent(8))
+  clauses -> should:be(indented_using:indent(1))
  end.
 
 if_expr() ->
  if {expressions_that_are_too_long_for_a_line,
-     [should,
-      be,
-      indented_using,
-      {sub_indent, 8}]} ->
+     [should, be, indented_using, {indent, 1}]} ->
      ok
  end.
 
@@ -62,13 +56,13 @@ a_function_with_a_very_long_name() ->
 
 block_expr() ->
  begin
-         block:expressions(),
-         should:be(indented_using:sub_indent(8))
+  block:expressions(),
+  should:be(indented_using:indent(1))
  end.
 
 catch_expr() ->
  catch
-         exp:ressions(should:be(indented_using:sub_indent(8))).
+  exp:ressions(should:be(indented_using:indent(1))).
 
 list_generator() ->
  [generators
@@ -90,23 +84,21 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
  receive
-         clauses ->
-          should:be(indented_using:sub_indent(8))
-         after
-                 ExpressionsThatAreReallyTooLongForALine ->
-                  should:be(indented_using:sub_indent(8))
+  clauses -> should:be(indented_using:indent(1))
+  after ExpressionsThatAreReallyTooLongForALine ->
+         should:be(indented_using:indent(1))
  end.
 
 try_expr() ->
  try expressions:that(are_too_long_for_a_line,
-                      should:be(indented_using:sub_indent(8)),
+                      should:be(indented_using:indent(1)),
                       but,
                       the)
  of
-         should -> not be:indented(at_all)
+  should -> not be:indented(at_all)
  catch
-         Clauses:Should:Also ->
-          be:indented(using:sub_indent(8))
+  Clauses:Should:Also ->
+   be:indented(using:indent(1))
  after
-         should:be(indented_using:sub_indent(8))
+  should:be(indented_using:indent(1))
  end.

--- a/test_app/after/src/indent_1.erl
+++ b/test_app/after/src/indent_1.erl
@@ -107,3 +107,13 @@ try_expr() ->
  after
   should:be(indented_using:break_indent(1))
  end.
+
+when_clause(A, B, C)
+ when is_integer(A),
+      B >= A andalso C rem 2 =:= 0 ->
+ the:guard(should:be(indented_using:break_indent(1)));
+when_clause(Along, Blonb, Clong)
+ when is_integer(Along),
+      Along >= Blong andalso
+       Clong rem Along =:= Blong ->
+ here:should(happen, the, same, thing).

--- a/test_app/after/src/indent_1.erl
+++ b/test_app/after/src/indent_1.erl
@@ -40,7 +40,10 @@ case_expr() ->
 
 if_expr() ->
  if {expressions_that_are_too_long_for_a_line,
-     [should, be, indented_using, {indent, 1}]} ->
+     [should,
+      be,
+      indented_using,
+      {break_indent, 1}]} ->
      ok
  end.
 

--- a/test_app/after/src/indent_1.erl
+++ b/test_app/after/src/indent_1.erl
@@ -16,7 +16,7 @@
 
 infix_expr() ->
  this:infix(expression) ++
-  should:be(indented) ++ using:indent(1).
+  should:be(indented) ++ using:break_indent(1).
 
 prefix_expr() ->
  ThisPrefixExpressionShould =
@@ -28,13 +28,14 @@ match_expr() ->
 
 case_expr() ->
  case expressions:that(are_too_long_for_a_line,
-                       should:be(indented_using:indent(1)),
+                       should:be(indented_using:break_indent(1)),
                        but,
                        the,
                        "of",
                        should:be(indented_using:break_indent(1)))
   of
-  clauses -> should:be(indented_using:indent(1))
+  clauses ->
+   should:be(indented_using:break_indent(1))
  end.
 
 if_expr() ->
@@ -57,12 +58,12 @@ a_function_with_a_very_long_name() ->
 block_expr() ->
  begin
   block:expressions(),
-  should:be(indented_using:indent(1))
+  should:be(indented_using:break_indent(1))
  end.
 
 catch_expr() ->
  catch
-  exp:ressions(should:be(indented_using:indent(1))).
+  exp:ressions(should:be(indented_using:break_indent(1))).
 
 list_generator() ->
  [generators
@@ -84,21 +85,22 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
  receive
-  clauses -> should:be(indented_using:indent(1))
+  clauses ->
+   should:be(indented_using:break_indent(1))
   after ExpressionsThatAreReallyTooLongForALine ->
-         should:be(indented_using:indent(1))
+         should:be(indented_using:break_indent(1))
  end.
 
 try_expr() ->
  try expressions:that(are_too_long_for_a_line,
-                      should:be(indented_using:indent(1)),
+                      should:be(indented_using:break_indent(1)),
                       but,
                       the)
  of
   should -> not be:indented(at_all)
  catch
   Clauses:Should:Also ->
-   be:indented(using:indent(1))
+   be:indented(using:break_indent(1))
  after
-  should:be(indented_using:indent(1))
+  should:be(indented_using:break_indent(1))
  end.

--- a/test_app/after/src/indent_8.erl
+++ b/test_app/after/src/indent_8.erl
@@ -1,8 +1,6 @@
--module(indent_81).
+-module(indent_8).
 
--format #{break_indent => 8,
-          paper => 50,
-          sub_indent => 1}.
+-format #{break_indent => 8, paper => 50}.
 -format #{inline_clause_bodies => true}.
 
 -record(record,
@@ -17,8 +15,8 @@
 
 infix_expr() ->
         this:infix(expression) ++
-         should:be(indented) ++
-          using:sub_indent(1).
+                should:be(indented) ++
+                        using:indent(8).
 
 prefix_expr() ->
         ThisPrefixExpressionShould =
@@ -30,25 +28,25 @@ match_expr() ->
 
 case_expr() ->
         case
-         expressions:that(are_too_long_for_a_line,
-                          should:be(indented_using:sub_indent(1)),
-                          but,
-                          the,
-                          "of",
-                          should:be(indented_using:break_indent(8)))
+                expressions:that(are_too_long_for_a_line,
+                                 should:be(indented_using:indent(8)),
+                                 but,
+                                 the,
+                                 "of",
+                                 should:be(indented_using:break_indent(8)))
                 of
-         clauses ->
-                 should:be(indented_using:sub_indent(1))
+                clauses ->
+                        should:be(indented_using:indent(8))
         end.
 
 if_expr() ->
         if
-         {expressions_that_are_too_long_for_a_line,
-          [should,
-           be,
-           indented_using,
-           {sub_indent, 1}]} ->
-                 ok
+                {expressions_that_are_too_long_for_a_line,
+                 [should,
+                  be,
+                  indented_using,
+                  {indent, 8}]} ->
+                        ok
         end.
 
 -type
@@ -64,13 +62,13 @@ a_function_with_a_very_long_name() ->
 
 block_expr() ->
         begin
-         block:expressions(),
-         should:be(indented_using:sub_indent(1))
+                block:expressions(),
+                should:be(indented_using:indent(8))
         end.
 
 catch_expr() ->
         catch
-         exp:ressions(should:be(indented_using:sub_indent(1))).
+                exp:ressions(should:be(indented_using:indent(8))).
 
 list_generator() ->
         [generators
@@ -92,24 +90,24 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
         receive
-         clauses ->
-                 should:be(indented_using:sub_indent(1))
-         after
-          ExpressionsThatAreReallyTooLongForALine ->
-                  should:be(indented_using:sub_indent(1))
+                clauses ->
+                        should:be(indented_using:indent(8))
+                after
+                        ExpressionsThatAreReallyTooLongForALine ->
+                                should:be(indented_using:indent(8))
         end.
 
 try_expr() ->
         try
-         expressions:that(are_too_long_for_a_line,
-                          should:be(indented_using:sub_indent(1)),
-                          but,
-                          the)
+                expressions:that(are_too_long_for_a_line,
+                                 should:be(indented_using:indent(8)),
+                                 but,
+                                 the)
         of
-         should -> not be:indented(at_all)
+                should -> not be:indented(at_all)
         catch
-         Clauses:Should:Also ->
-                 be:indented(using:sub_indent(1))
+                Clauses:Should:Also ->
+                        be:indented(using:indent(8))
         after
-         should:be(indented_using:sub_indent(1))
+                should:be(indented_using:indent(8))
         end.

--- a/test_app/after/src/indent_8.erl
+++ b/test_app/after/src/indent_8.erl
@@ -45,7 +45,7 @@ if_expr() ->
                  [should,
                   be,
                   indented_using,
-                  {indent, 8}]} ->
+                  {break_indent, 8}]} ->
                         ok
         end.
 

--- a/test_app/after/src/indent_8.erl
+++ b/test_app/after/src/indent_8.erl
@@ -16,7 +16,7 @@
 infix_expr() ->
         this:infix(expression) ++
                 should:be(indented) ++
-                        using:indent(8).
+                        using:break_indent(8).
 
 prefix_expr() ->
         ThisPrefixExpressionShould =
@@ -29,14 +29,14 @@ match_expr() ->
 case_expr() ->
         case
                 expressions:that(are_too_long_for_a_line,
-                                 should:be(indented_using:indent(8)),
+                                 should:be(indented_using:break_indent(8)),
                                  but,
                                  the,
                                  "of",
                                  should:be(indented_using:break_indent(8)))
                 of
                 clauses ->
-                        should:be(indented_using:indent(8))
+                        should:be(indented_using:break_indent(8))
         end.
 
 if_expr() ->
@@ -63,12 +63,12 @@ a_function_with_a_very_long_name() ->
 block_expr() ->
         begin
                 block:expressions(),
-                should:be(indented_using:indent(8))
+                should:be(indented_using:break_indent(8))
         end.
 
 catch_expr() ->
         catch
-                exp:ressions(should:be(indented_using:indent(8))).
+                exp:ressions(should:be(indented_using:break_indent(8))).
 
 list_generator() ->
         [generators
@@ -91,23 +91,23 @@ binary_generator() ->
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
         receive
                 clauses ->
-                        should:be(indented_using:indent(8))
+                        should:be(indented_using:break_indent(8))
                 after
                         ExpressionsThatAreReallyTooLongForALine ->
-                                should:be(indented_using:indent(8))
+                                should:be(indented_using:break_indent(8))
         end.
 
 try_expr() ->
         try
                 expressions:that(are_too_long_for_a_line,
-                                 should:be(indented_using:indent(8)),
+                                 should:be(indented_using:break_indent(8)),
                                  but,
                                  the)
         of
                 should -> not be:indented(at_all)
         catch
                 Clauses:Should:Also ->
-                        be:indented(using:indent(8))
+                        be:indented(using:break_indent(8))
         after
-                should:be(indented_using:indent(8))
+                should:be(indented_using:break_indent(8))
         end.

--- a/test_app/after/src/indent_8.erl
+++ b/test_app/after/src/indent_8.erl
@@ -111,3 +111,13 @@ try_expr() ->
         after
                 should:be(indented_using:break_indent(8))
         end.
+
+when_clause(A, B, C)
+        when is_integer(A),
+             B >= A andalso C rem 2 =:= 0 ->
+        the:guard(should:be(indented_using:break_indent(8)));
+when_clause(Along, Blonb, Clong)
+        when is_integer(Along),
+             Along >= Blong andalso
+                     Clong rem Along =:= Blong ->
+        here:should(happen, the, same, thing).

--- a/test_app/after/src/inline_clause_bodies.erl
+++ b/test_app/after/src/inline_clause_bodies.erl
@@ -18,17 +18,17 @@ f_cs(inline, this, other, much_much_larger_clause) ->
 
 case_expr_clauses(Inline) ->
     case Inline of
-      {this, clause} ->
-          [just, like];
-      {this, other} ->
-          [much,
-           much,
-           larger,
-           clause,
-           please,
-           mister,
-           rebar3,
-           formatter]
+        {this, clause} ->
+            [just, like];
+        {this, other} ->
+            [much,
+             much,
+             larger,
+             clause,
+             please,
+             mister,
+             rebar3,
+             formatter]
     end.
 
 if_expr_clauses(Inline) ->
@@ -77,42 +77,42 @@ named_fun_expr_clauses() ->
 
 receive_expr_clauses() ->
     receive
-      {inline, this, clause} ->
-          [just, like];
-      {this, other} ->
-          [much,
-           much,
-           larger,
-           clause,
-           please,
-           mister,
-           rebar3,
-           formatter]
+        {inline, this, clause} ->
+            [just, like];
+        {this, other} ->
+            [much,
+             much,
+             larger,
+             clause,
+             please,
+             mister,
+             rebar3,
+             formatter]
     end.
 
 try_expr(Inline) ->
     try Inline() of
-      {this, clause} ->
-          [just, like];
-      {this, other} ->
-          [much,
-           much,
-           larger,
-           clause,
-           please,
-           mister,
-           rebar3,
-           formatter]
+        {this, clause} ->
+            [just, like];
+        {this, other} ->
+            [much,
+             much,
+             larger,
+             clause,
+             please,
+             mister,
+             rebar3,
+             formatter]
     catch
-      _This:clause ->
-          [just, like];
-      _This:_Other ->
-          [much,
-           much,
-           larger,
-           clause,
-           please,
-           mister,
-           rebar3,
-           formatter]
+        _This:clause ->
+            [just, like];
+        _This:_Other ->
+            [much,
+             much,
+             larger,
+             clause,
+             please,
+             mister,
+             rebar3,
+             formatter]
     end.

--- a/test_app/after/src/inline_items.erl
+++ b/test_app/after/src/inline_items.erl
@@ -53,10 +53,10 @@ short_bin() ->
 -spec short_guard(integer()) -> integer().
 short_guard(X) when is_integer(X), X < 2 ->
     case X of
-      X when X >= -1 ->
-          X + 1;
-      X ->
-          X
+        X when X >= -1 ->
+            X + 1;
+        X ->
+            X
     end.
 
 -spec short_lc() -> [{_, _, _}].
@@ -307,7 +307,7 @@ long_arglist(X1,
              VeryVeryLongName2,
              VeryVeryLongName3) ->
     X1 + X2 + X3 + Y1 + VeryVeryLongName1 + VeryVeryLongName2 +
-      VeryVeryLongName3.
+        VeryVeryLongName3.
 
 -spec long_rec() ->
                   #long_rec{x1 :: x1,

--- a/test_app/after/src/others.erl
+++ b/test_app/after/src/others.erl
@@ -42,8 +42,8 @@ parentheses() ->
 
 receive_expr() ->
     receive
-      with ->
-          {no, timeout}
+        with ->
+            {no, timeout}
     end.
 
 record_index_expr(List) ->
@@ -51,26 +51,26 @@ record_index_expr(List) ->
 
 try_expr_after() ->
     try to:open({the, door}) of
-      my ->
-          room or your;
-      room ->
-          {my, friend}
+        my ->
+            room or your;
+        room ->
+            {my, friend}
     catch
-      {you_cant, Open} when Open ->
-          it:was(Open)
+        {you_cant, Open} when Open ->
+            it:was(Open)
     after
-      close:the(door, anyway)
+        close:the(door, anyway)
     end,
     try
-      with:no(catching)
+        with:no(catching)
     after
-      do:something({to,
-                    "clean up",
-                    <<"the">>,
-                    [filthy, filthy, mess],
-                    you,
-                    created,
-                    "if you can"})
+        do:something({to,
+                      "clean up",
+                      <<"the">>,
+                      [filthy, filthy, mess],
+                      you,
+                      created,
+                      "if you can"})
     end.
 
 bit_types(X) ->
@@ -78,9 +78,9 @@ bit_types(X) ->
 
 multi_try_expr() ->
     try
-      there:are(2),
-      expressions:in(this_block)
+        there:are(2),
+        expressions:in(this_block)
     catch
-      A:Catch:Expression ->
-          formatter:should(indent, A, Catch, Expression)
+        A:Catch:Expression ->
+            formatter:should(indent, A, Catch, Expression)
     end.

--- a/test_app/after/src/receive_after.erl
+++ b/test_app/after/src/receive_after.erl
@@ -5,6 +5,6 @@
 %% This function should not generate a line with 4 spaces between receive and after
 sleep(T) ->
     receive
-      after T ->
-                io:format("Waking up after ~p milliseconds to keep on working as usual!!~n", [T])
+        after T ->
+                  io:format("Waking up after ~p milliseconds to keep on working as usual!!~n", [T])
     end.

--- a/test_app/after/src/syntax_tools_SUITE_test_module.erl
+++ b/test_app/after/src/syntax_tools_SUITE_test_module.erl
@@ -144,10 +144,10 @@ str(S, Sub) when is_list(Sub) ->
 
 str([C | S], [C | Sub], I) ->
     case prefix(Sub, S) of
-      true ->
-          I;
-      false ->
-          str(S, [C | Sub], I + 1)
+        true ->
+            I;
+        false ->
+            str(S, [C | Sub], I + 1)
     end;
 str([_ | S], Sub, I) ->
     str(S, Sub, I + 1);
@@ -162,10 +162,10 @@ rstr(S, Sub) when is_list(Sub) ->
 
 rstr([C | S], [C | Sub], I, L) ->
     case prefix(Sub, S) of
-      true ->
-          rstr(S, [C | Sub], I + 1, I);
-      false ->
-          rstr(S, [C | Sub], I + 1, L)
+        true ->
+            rstr(S, [C | Sub], I + 1, I);
+        false ->
+            rstr(S, [C | Sub], I + 1, L)
     end;
 rstr([_ | S], Sub, I, L) ->
     rstr(S, Sub, I + 1, L);
@@ -190,10 +190,10 @@ span(S, Cs) when is_list(Cs) ->
 
 span([C | S], Cs, I) ->
     case member(C, Cs) of
-      true ->
-          span(S, Cs, I + 1);
-      false ->
-          I
+        true ->
+            span(S, Cs, I + 1);
+        false ->
+            I
     end;
 span([], _Cs, I) ->
     I.
@@ -206,10 +206,10 @@ cspan(S, Cs) when is_list(Cs) ->
 
 cspan([C | S], Cs, I) ->
     case member(C, Cs) of
-      true ->
-          I;
-      false ->
-          cspan(S, Cs, I + 1)
+        true ->
+            I;
+        false ->
+            cspan(S, Cs, I + 1)
     end;
 cspan([], _Cs, I) ->
     I.
@@ -254,20 +254,20 @@ tokens(S, Seps) ->
 
 tokens1([C | S], Seps, Toks) ->
     case member(C, Seps) of
-      true ->
-          tokens1(S, Seps, Toks);
-      false ->
-          tokens2(S, Seps, Toks, [C])
+        true ->
+            tokens1(S, Seps, Toks);
+        false ->
+            tokens2(S, Seps, Toks, [C])
     end;
 tokens1([], _Seps, Toks) ->
     reverse(Toks).
 
 tokens2([C | S], Seps, Toks, Cs) ->
     case member(C, Seps) of
-      true ->
-          tokens1(S, Seps, [reverse(Cs) | Toks]);
-      false ->
-          tokens2(S, Seps, Toks, [C | Cs])
+        true ->
+            tokens1(S, Seps, [reverse(Cs) | Toks]);
+        false ->
+            tokens2(S, Seps, Toks, [C | Cs])
     end;
 tokens2([], _Seps, Toks, Cs) ->
     reverse([reverse(Cs) | Toks]).
@@ -335,10 +335,10 @@ sub_word(String, Index) ->
                                                        Character :: char().
 sub_word(String, Index, Char) when is_integer(Index), is_integer(Char) ->
     case words(String, Char) of
-      Num when Num < Index ->
-          [];
-      _Num ->
-          s_word(strip(String, left, Char), Index, Char, 1, [])
+        Num when Num < Index ->
+            [];
+        _Num ->
+            s_word(strip(String, left, Char), Index, Char, 1, [])
     end.
 
 s_word([], _, _, _, Res) ->
@@ -388,10 +388,10 @@ strip_left([], Sc) when is_integer(Sc) ->
 
 strip_right([Sc | S], Sc) ->
     case strip_right(S, Sc) of
-      [] ->
-          [];
-      T ->
-          [Sc | T]
+        [] ->
+            [];
+        T ->
+            [Sc | T]
     end;
 strip_right([C | S], Sc) ->
     [C | strip_right(S, Sc)];

--- a/test_app/after/src/syntax_tools_test.erl
+++ b/test_app/after/src/syntax_tools_test.erl
@@ -90,22 +90,22 @@ foo2(A, B) ->
                               3.14
                        end),
       ?macro_argument1(case A of
-                         ok ->
-                             B;
-                         C ->
-                             C
+                           ok ->
+                               B;
+                           C ->
+                               C
                        end),
       ?macro_argument1(receive
-                         M ->
-                             M
-                         after 100 ->
-                                   3
+                           M ->
+                               M
+                           after 100 ->
+                                     3
                        end),
       ?macro_argument1(try
-                         foo5(A)
+                           foo5(A)
                        catch
-                         C:?macro_simple5 ->
-                             {C, B}
+                           C:?macro_simple5 ->
+                               {C, B}
                        end),
       ?macro_argument2(A, B)],
      A,
@@ -155,9 +155,9 @@ foo4(A, B, #state{c = C} = S) ->
 
 foo5(A) ->
     try foo2(A, A) of
-      R ->
-          R
+        R ->
+            R
     catch
-      error:?macro_simple5 ->
-          nope
+        error:?macro_simple5 ->
+            nope
     end.

--- a/test_app/after/src/type_specs.erl
+++ b/test_app/after/src/type_specs.erl
@@ -67,8 +67,8 @@ f({R, R}) ->
 -spec type_specs:b() -> pos_integer().
 b() ->
     case foo:bar() of
-      #{a := 2} ->
-          19
+        #{a := 2} ->
+            19
     end.
 
 -define(I, integer).

--- a/test_app/after/src/weird.erl
+++ b/test_app/after/src/weird.erl
@@ -27,10 +27,10 @@ newlines(Num) ->
 %% @doc No specs!
 cases(V) when is_list(V) ->
     case V of
-      [] ->
-          ok;
-      _ ->
-          {error, "Uops!"}
+        [] ->
+            ok;
+        _ ->
+            {error, "Uops!"}
     end;
 cases(_) ->
     ok.

--- a/test_app/src/indent_1.erl
+++ b/test_app/src/indent_1.erl
@@ -1,6 +1,6 @@
--module(indent_18).
+-module(indent_1).
 
--format(#{break_indent => 1, sub_indent => 8, paper => 50, inline_clause_bodies => true}).
+-format(#{break_indent => 1, paper => 50, inline_clause_bodies => true}).
 
 -record(
     record, {fields = should:be(indented_using:break_indent(1)),
@@ -8,7 +8,7 @@
                 what_about = fields_with:very_long_values(and_very:long_type_names()) :: they:also(should:be(indented_using:break_indent(1)))}).
 
 infix_expr() ->
-    this:infix(expression) ++ should:be(indented) ++ using:sub_indent(8).
+    this:infix(expression) ++ should:be(indented) ++ using:indent(1).
 
 prefix_expr() ->
     ThisPrefixExpressionShould = not use:break_indent(1).
@@ -19,14 +19,14 @@ match_expr() ->
 case_expr() ->
     case expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:sub_indent(8)),
+            should:be(indented_using:indent(1)),
             but, the, "of", should:be(indented_using:break_indent(1))) of
-        clauses -> should:be(indented_using:sub_indent(8))
+        clauses -> should:be(indented_using:indent(1))
     end.
 
 if_expr() ->
     if {expressions_that_are_too_long_for_a_line,
-            [should, be, indented_using, {sub_indent, 8}]} ->
+            [should, be, indented_using, {indent, 1}]} ->
         ok
     end.
 
@@ -38,11 +38,11 @@ a_function_with_a_very_long_name() ->
 block_expr() ->
     begin
         block:expressions(),
-        should:be(indented_using:sub_indent(8))
+        should:be(indented_using:indent(1))
     end.
 
 catch_expr() ->
-    catch exp:ressions(should:be(indented_using:sub_indent(8))).
+    catch exp:ressions(should:be(indented_using:indent(1))).
 
 list_generator() ->
     [generators || _In <- list:comprehensions(should:be(indented_using:break_indent(1))),
@@ -54,17 +54,17 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
     receive
-        clauses -> should:be(indented_using:sub_indent(8))
-    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:sub_indent(8))
+        clauses -> should:be(indented_using:indent(1))
+    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:indent(1))
     end.
 
 try_expr() ->
     try expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:sub_indent(8)),
+            should:be(indented_using:indent(1)),
             but, the) of
         should -> not be:indented(at_all)
     catch
-        Clauses:Should:Also -> be:indented(using:sub_indent(8))
-    after should:be(indented_using:sub_indent(8))
+        Clauses:Should:Also -> be:indented(using:indent(1))
+    after should:be(indented_using:indent(1))
     end.

--- a/test_app/src/indent_1.erl
+++ b/test_app/src/indent_1.erl
@@ -8,7 +8,7 @@
                 what_about = fields_with:very_long_values(and_very:long_type_names()) :: they:also(should:be(indented_using:break_indent(1)))}).
 
 infix_expr() ->
-    this:infix(expression) ++ should:be(indented) ++ using:indent(1).
+    this:infix(expression) ++ should:be(indented) ++ using:break_indent(1).
 
 prefix_expr() ->
     ThisPrefixExpressionShould = not use:break_indent(1).
@@ -19,9 +19,9 @@ match_expr() ->
 case_expr() ->
     case expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:indent(1)),
+            should:be(indented_using:break_indent(1)),
             but, the, "of", should:be(indented_using:break_indent(1))) of
-        clauses -> should:be(indented_using:indent(1))
+        clauses -> should:be(indented_using:break_indent(1))
     end.
 
 if_expr() ->
@@ -38,11 +38,11 @@ a_function_with_a_very_long_name() ->
 block_expr() ->
     begin
         block:expressions(),
-        should:be(indented_using:indent(1))
+        should:be(indented_using:break_indent(1))
     end.
 
 catch_expr() ->
-    catch exp:ressions(should:be(indented_using:indent(1))).
+    catch exp:ressions(should:be(indented_using:break_indent(1))).
 
 list_generator() ->
     [generators || _In <- list:comprehensions(should:be(indented_using:break_indent(1))),
@@ -54,17 +54,17 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
     receive
-        clauses -> should:be(indented_using:indent(1))
-    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:indent(1))
+        clauses -> should:be(indented_using:break_indent(1))
+    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:break_indent(1))
     end.
 
 try_expr() ->
     try expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:indent(1)),
+            should:be(indented_using:break_indent(1)),
             but, the) of
         should -> not be:indented(at_all)
     catch
-        Clauses:Should:Also -> be:indented(using:indent(1))
-    after should:be(indented_using:indent(1))
+        Clauses:Should:Also -> be:indented(using:break_indent(1))
+    after should:be(indented_using:break_indent(1))
     end.

--- a/test_app/src/indent_1.erl
+++ b/test_app/src/indent_1.erl
@@ -68,3 +68,8 @@ try_expr() ->
         Clauses:Should:Also -> be:indented(using:break_indent(1))
     after should:be(indented_using:break_indent(1))
     end.
+
+when_clause(A, B, C) when is_integer(A), B >= A andalso C rem 2 =:= 0 ->
+    the:guard(should:be(indented_using:break_indent(1)));
+when_clause(Along, Blonb, Clong) when is_integer(Along), Along >= Blong andalso Clong rem Along =:= Blong ->
+    here:should(happen, the, same, thing).

--- a/test_app/src/indent_1.erl
+++ b/test_app/src/indent_1.erl
@@ -26,7 +26,7 @@ case_expr() ->
 
 if_expr() ->
     if {expressions_that_are_too_long_for_a_line,
-            [should, be, indented_using, {indent, 1}]} ->
+            [should, be, indented_using, {break_indent, 1}]} ->
         ok
     end.
 

--- a/test_app/src/indent_8.erl
+++ b/test_app/src/indent_8.erl
@@ -69,3 +69,8 @@ try_expr() ->
         Clauses:Should:Also -> be:indented(using:break_indent(8))
     after should:be(indented_using:break_indent(8))
     end.
+
+when_clause(A, B, C) when is_integer(A), B >= A andalso C rem 2 =:= 0 ->
+    the:guard(should:be(indented_using:break_indent(8)));
+when_clause(Along, Blonb, Clong) when is_integer(Along), Along >= Blong andalso Clong rem Along =:= Blong ->
+    here:should(happen, the, same, thing).

--- a/test_app/src/indent_8.erl
+++ b/test_app/src/indent_8.erl
@@ -27,7 +27,7 @@ case_expr() ->
 
 if_expr() ->
     if {expressions_that_are_too_long_for_a_line,
-            [should, be, indented_using, {indent, 8}]} ->
+            [should, be, indented_using, {break_indent, 8}]} ->
         ok
     end.
 

--- a/test_app/src/indent_8.erl
+++ b/test_app/src/indent_8.erl
@@ -9,7 +9,7 @@
                 what_about = fields_with:very_long_values(and_very:long_type_names()) :: they:also(should:be(indented_using:break_indent(8)))}).
 
 infix_expr() ->
-    this:infix(expression) ++ should:be(indented) ++ using:indent(8).
+    this:infix(expression) ++ should:be(indented) ++ using:break_indent(8).
 
 prefix_expr() ->
     ThisPrefixExpressionShould = not use:break_indent(8).
@@ -20,9 +20,9 @@ match_expr() ->
 case_expr() ->
     case expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:indent(8)),
+            should:be(indented_using:break_indent(8)),
             but, the, "of", should:be(indented_using:break_indent(8))) of
-        clauses -> should:be(indented_using:indent(8))
+        clauses -> should:be(indented_using:break_indent(8))
     end.
 
 if_expr() ->
@@ -39,11 +39,11 @@ a_function_with_a_very_long_name() ->
 block_expr() ->
     begin
         block:expressions(),
-        should:be(indented_using:indent(8))
+        should:be(indented_using:break_indent(8))
     end.
 
 catch_expr() ->
-    catch exp:ressions(should:be(indented_using:indent(8))).
+    catch exp:ressions(should:be(indented_using:break_indent(8))).
 
 list_generator() ->
     [generators || _In <- list:comprehensions(should:be(indented_using:break_indent(8))),
@@ -55,17 +55,17 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
     receive
-        clauses -> should:be(indented_using:indent(8))
-    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:indent(8))
+        clauses -> should:be(indented_using:break_indent(8))
+    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:break_indent(8))
     end.
 
 try_expr() ->
     try expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:indent(8)),
+            should:be(indented_using:break_indent(8)),
             but, the) of
         should -> not be:indented(at_all)
     catch
-        Clauses:Should:Also -> be:indented(using:indent(8))
-    after should:be(indented_using:indent(8))
+        Clauses:Should:Also -> be:indented(using:break_indent(8))
+    after should:be(indented_using:break_indent(8))
     end.

--- a/test_app/src/indent_8.erl
+++ b/test_app/src/indent_8.erl
@@ -1,6 +1,6 @@
--module(indent_81).
+-module(indent_8).
 
--format(#{break_indent => 8, sub_indent => 1, paper => 50}).
+-format(#{break_indent => 8, paper => 50}).
 -format(#{inline_clause_bodies => true}).
 
 -record(
@@ -9,7 +9,7 @@
                 what_about = fields_with:very_long_values(and_very:long_type_names()) :: they:also(should:be(indented_using:break_indent(8)))}).
 
 infix_expr() ->
-    this:infix(expression) ++ should:be(indented) ++ using:sub_indent(1).
+    this:infix(expression) ++ should:be(indented) ++ using:indent(8).
 
 prefix_expr() ->
     ThisPrefixExpressionShould = not use:break_indent(8).
@@ -20,14 +20,14 @@ match_expr() ->
 case_expr() ->
     case expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:sub_indent(1)),
+            should:be(indented_using:indent(8)),
             but, the, "of", should:be(indented_using:break_indent(8))) of
-        clauses -> should:be(indented_using:sub_indent(1))
+        clauses -> should:be(indented_using:indent(8))
     end.
 
 if_expr() ->
     if {expressions_that_are_too_long_for_a_line,
-            [should, be, indented_using, {sub_indent, 1}]} ->
+            [should, be, indented_using, {indent, 8}]} ->
         ok
     end.
 
@@ -39,11 +39,11 @@ a_function_with_a_very_long_name() ->
 block_expr() ->
     begin
         block:expressions(),
-        should:be(indented_using:sub_indent(1))
+        should:be(indented_using:indent(8))
     end.
 
 catch_expr() ->
-    catch exp:ressions(should:be(indented_using:sub_indent(1))).
+    catch exp:ressions(should:be(indented_using:indent(8))).
 
 list_generator() ->
     [generators || _In <- list:comprehensions(should:be(indented_using:break_indent(8))),
@@ -55,17 +55,17 @@ binary_generator() ->
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
     receive
-        clauses -> should:be(indented_using:sub_indent(1))
-    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:sub_indent(1))
+        clauses -> should:be(indented_using:indent(8))
+    after ExpressionsThatAreReallyTooLongForALine -> should:be(indented_using:indent(8))
     end.
 
 try_expr() ->
     try expressions:that(
             are_too_long_for_a_line,
-            should:be(indented_using:sub_indent(1)),
+            should:be(indented_using:indent(8)),
             but, the) of
         should -> not be:indented(at_all)
     catch
-        Clauses:Should:Also -> be:indented(using:sub_indent(1))
-    after should:be(indented_using:sub_indent(1))
+        Clauses:Should:Also -> be:indented(using:indent(8))
+    after should:be(indented_using:indent(8))
     end.


### PR DESCRIPTION
To fix #131, I just removed `sub_indent`. I didn't change `break_indent`'s name to just `indent` since it's still different from other _indentation_ rules, like the one for indenting items in a list, where the elements are indented by `1` only, e.g.:

```erlang
    [first,
     second,
     third]
```