### PR TITLE
[Fix #140] Indent on function composition

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
-{"1.1.0",
+{"1.2.0",
 [{<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.2.1">>},0}]}.
 [
 {pkg_hash,[
- {<<"katana_code">>, <<"B2195859DF57D8BEBF619A9FD3327CD7D01563A98417156D0F4C5FAB435F2630">>}]}
+ {<<"katana_code">>, <<"B2195859DF57D8BEBF619A9FD3327CD7D01563A98417156D0F4C5FAB435F2630">>}]},
+{pkg_hash_ext,[
+ {<<"katana_code">>, <<"8448AD3F56D9814F98A28BE650F7191BDD506575E345CC16D586660B10F6E992">>}]}
 ].

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -88,7 +88,9 @@ format(Node, EmptyLines, Options) ->
                 []
         end,
     PreFormatted = prettypr:format(layout(Node, FinalEmptyLines, Options), W, L),
-    Formatted = remove_tabs(unicode:characters_to_binary(PreFormatted, E)),
+    Formatted =
+        remove_tabs(
+            unicode:characters_to_binary(PreFormatted, E)),
     remove_trailing_spaces(Formatted).
 
 %% @doc Initialize the formatter and generate a state that will be passed in when
@@ -145,8 +147,11 @@ lay(Node, Ctxt) ->
     case erl_syntax:has_comments(Node) of
         true ->
             D1 = lay_no_comments(Node, Ctxt),
-            D2 = lay_postcomments(erl_syntax:get_postcomments(Node), D1),
-            lay_precomments(erl_syntax:get_precomments(Node), D2);
+            D2 =
+                lay_postcomments(
+                    erl_syntax:get_postcomments(Node), D1),
+            lay_precomments(
+                erl_syntax:get_precomments(Node), D2);
         false ->
             lay_no_comments(Node, Ctxt)
     end.
@@ -166,7 +171,9 @@ lay_postcomments(Cs, D) ->
 %% Format (including padding, if `Pad' is `true', otherwise not)
 %% and stack the listed comments above each other.
 stack_comments([C | Cs], Pad) ->
-    D = stack_comment_lines(erl_syntax:comment_text(C)),
+    D =
+        stack_comment_lines(
+            erl_syntax:comment_text(C)),
     D1 =
         case Pad of
             true ->
@@ -209,7 +216,8 @@ lay_no_comments(Node, Ctxt) ->
     case erl_syntax:type(Node) of
         %% We list literals and other common cases first.
         variable ->
-            text(erl_syntax:variable_literal(Node));
+            text(
+                erl_syntax:variable_literal(Node));
         atom ->
             text(tidy_atom(Node, Ctxt));
         integer ->
@@ -223,12 +231,16 @@ lay_no_comments(Node, Ctxt) ->
         nil ->
             text("[]");
         tuple ->
-            Es = lay_items(erl_syntax:tuple_elements(Node), reset_prec(Ctxt), fun lay/2),
+            Es =
+                lay_items(
+                    erl_syntax:tuple_elements(Node), reset_prec(Ctxt), fun lay/2),
             beside(lay_text_float("{"), beside(Es, lay_text_float("}")));
         list ->
             Ctxt1 = reset_prec(Ctxt),
             Node1 = erl_syntax:compact_list(Node),
-            D1 = lay_items(erl_syntax:list_prefix(Node1), Ctxt1, fun lay/2),
+            D1 =
+                lay_items(
+                    erl_syntax:list_prefix(Node1), Ctxt1, fun lay/2),
             D =
                 case erl_syntax:list_suffix(Node1) of
                     none ->
@@ -240,19 +252,25 @@ lay_no_comments(Node, Ctxt) ->
                 end,
             beside(lay_text_float("["), D);
         operator ->
-            lay_text_float(erl_syntax:operator_literal(Node));
+            lay_text_float(
+                erl_syntax:operator_literal(Node));
         infix_expr ->
             Operator = erl_syntax:infix_expr_operator(Node),
             {PrecL, Prec, PrecR} =
                 case erl_syntax:type(Operator) of
                     operator ->
-                        inop_prec(erl_syntax:operator_name(Operator));
+                        inop_prec(
+                            erl_syntax:operator_name(Operator));
                     _ ->
                         {0, 0, 0}
                 end,
-            D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
+            D1 =
+                lay(
+                    erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
             D2 = lay(Operator, reset_prec(Ctxt)),
-            D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
+            D3 =
+                lay(
+                    erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
             D4 = par([D1, D2, D3], Ctxt#ctxt.break_indent),
             maybe_parentheses(D4, Prec, Ctxt);
         prefix_expr ->
@@ -266,7 +284,9 @@ lay_no_comments(Node, Ctxt) ->
                         {{0, 0}, any}
                 end,
             D1 = lay(Operator, reset_prec(Ctxt)),
-            D2 = lay(erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
+            D2 =
+                lay(
+                    erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
             D3 =
                 case Name of
                     '+' ->
@@ -278,13 +298,18 @@ lay_no_comments(Node, Ctxt) ->
                 end,
             maybe_parentheses(D3, Prec, Ctxt);
         application ->
-            lay_application(erl_syntax:application_operator(Node),
-                            erl_syntax:application_arguments(Node),
-                            Ctxt);
+            lay_application(
+                erl_syntax:application_operator(Node),
+                erl_syntax:application_arguments(Node),
+                Ctxt);
         match_expr ->
             {PrecL, Prec, PrecR} = inop_prec('='),
-            D1 = lay(erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
-            D2 = lay(erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                lay(
+                    erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
             D3 = sep([beside(D1, lay_text_float(" =")), nest(Ctxt#ctxt.break_indent, D2)]),
             maybe_parentheses(D3, Prec, Ctxt);
         underscore ->
@@ -292,7 +317,9 @@ lay_no_comments(Node, Ctxt) ->
         clause ->
             %% The style used for a clause depends on its context
             Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
-            D1 = lay_items(erl_syntax:clause_patterns(Node), Ctxt1, fun lay/2),
+            D1 =
+                lay_items(
+                    erl_syntax:clause_patterns(Node), Ctxt1, fun lay/2),
             D2 =
                 case erl_syntax:clause_guard(Node) of
                     none ->
@@ -300,7 +327,9 @@ lay_no_comments(Node, Ctxt) ->
                     G ->
                         lay(G, Ctxt1)
                 end,
-            D3 = lay_clause_expressions(erl_syntax:clause_body(Node), Ctxt1, fun lay/2),
+            D3 =
+                lay_clause_expressions(
+                    erl_syntax:clause_body(Node), Ctxt1, fun lay/2),
             case Ctxt#ctxt.clause of
                 fun_expr ->
                     make_fun_clause(D1, D2, D3, Ctxt);
@@ -323,42 +352,66 @@ lay_no_comments(Node, Ctxt) ->
             %% Comments on the name itself will be repeated for each
             %% clause, but that seems to be the best way to handle it.
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:function_name(Node), Ctxt1),
-            D2 = lay_clauses(erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:function_name(Node), Ctxt1),
+            D2 =
+                lay_clauses(
+                    erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
             beside(D2, lay_text_float("."));
         case_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:case_expr_argument(Node), Ctxt1),
-            D2 = lay_clauses(erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:case_expr_argument(Node), Ctxt1),
+            D2 =
+                lay_clauses(
+                    erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
             sep([par([follow(text("case"), D1, Ctxt1#ctxt.break_indent), text("of")],
                      Ctxt1#ctxt.break_indent),
                  nest(Ctxt1#ctxt.break_indent, D2),
                  text("end")]);
         if_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
+            D =
+                lay_clauses(
+                    erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
             sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
         fun_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
+            Clauses =
+                lay_clauses(
+                    erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
             lay_fun_sep(Clauses, Ctxt1);
         named_fun_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:named_fun_expr_name(Node), Ctxt1),
-            Clauses = lay_clauses(erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:named_fun_expr_name(Node), Ctxt1),
+            Clauses =
+                lay_clauses(
+                    erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
             lay_fun_sep(Clauses, Ctxt1);
         module_qualifier ->
             {PrecL, _Prec, PrecR} = inop_prec(':'),
-            D1 = lay(erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
-            D2 = lay(erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                lay(
+                    erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
             beside(D1, beside(text(":"), D2));
         %%
         %% The rest is in alphabetical order (except map and types)
         %%
         arity_qualifier ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:arity_qualifier_body(Node), Ctxt1),
-            D2 = lay(erl_syntax:arity_qualifier_argument(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:arity_qualifier_body(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:arity_qualifier_argument(Node), Ctxt1),
             beside(D1, beside(text("/"), D2));
         attribute ->
             %% The attribute name and arguments are formatted similar to
@@ -428,11 +481,15 @@ lay_no_comments(Node, Ctxt) ->
             beside(lay_text_float("-"), beside(D, lay_text_float(".")));
         binary ->
             Ctxt1 = reset_prec(Ctxt),
-            Es = lay_items(erl_syntax:binary_fields(Node), Ctxt1, fun lay/2),
+            Es =
+                lay_items(
+                    erl_syntax:binary_fields(Node), Ctxt1, fun lay/2),
             beside(lay_text_float("<<"), beside(Es, lay_text_float(">>")));
         binary_field ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 = lay(erl_syntax:binary_field_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:binary_field_body(Node), Ctxt1),
             D2 =
                 case erl_syntax:binary_field_types(Node) of
                     [] ->
@@ -443,17 +500,25 @@ lay_no_comments(Node, Ctxt) ->
             beside(D1, D2);
         block_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            Es = lay_clause_expressions(erl_syntax:block_expr_body(Node), Ctxt1, fun lay/2),
+            Es =
+                lay_clause_expressions(
+                    erl_syntax:block_expr_body(Node), Ctxt1, fun lay/2),
             sep([text("begin"), nest(Ctxt1#ctxt.break_indent, Es), text("end")]);
         catch_expr ->
             {Prec, PrecR} = preop_prec('catch'),
-            D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D =
+                lay(
+                    erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
             D1 = follow(text("catch"), D, Ctxt#ctxt.break_indent),
             maybe_parentheses(D1, Prec, Ctxt);
         class_qualifier ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 = lay(erl_syntax:class_qualifier_argument(Node), Ctxt1),
-            D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:class_qualifier_argument(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:class_qualifier_body(Node), Ctxt1),
             Stacktrace = erl_syntax:class_qualifier_stacktrace(Node),
             case erl_syntax:variable_name(Stacktrace) of
                 '_' ->
@@ -463,7 +528,9 @@ lay_no_comments(Node, Ctxt) ->
                     beside(D1, beside(beside(text(":"), D2), beside(text(":"), D3)))
             end;
         comment ->
-            D = stack_comment_lines(erl_syntax:comment_text(Node)),
+            D =
+                stack_comment_lines(
+                    erl_syntax:comment_text(Node)),
             %% Default padding for standalone comments is empty.
             case erl_syntax:comment_padding(Node) of
                 none ->
@@ -472,11 +539,13 @@ lay_no_comments(Node, Ctxt) ->
                     floating(break(beside(text(spaces(P)), D)))
             end;
         conjunction ->
-            lay_items(erl_syntax:conjunction_body(Node), reset_prec(Ctxt), fun lay/2);
+            lay_items(
+                erl_syntax:conjunction_body(Node), reset_prec(Ctxt), fun lay/2);
         disjunction ->
             %% For clarity, we don't paragraph-format
             %% disjunctions; only conjunctions (see above).
-            sep(seq(erl_syntax:disjunction_body(Node),
+            sep(seq(
+                    erl_syntax:disjunction_body(Node),
                     lay_text_float(";"),
                     reset_prec(Ctxt),
                     fun lay/2));
@@ -486,32 +555,55 @@ lay_no_comments(Node, Ctxt) ->
         eof_marker ->
             empty();
         form_list ->
-            Es = seq(erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
-            AddEmptyLines = empty_lines_to_add(erl_syntax:form_list_elements(Node), Ctxt),
-            vertical_sep(lists:zip(Es, AddEmptyLines));
+            Es =
+                seq(
+                    erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
+            AddEmptyLines =
+                empty_lines_to_add(
+                    erl_syntax:form_list_elements(Node), Ctxt),
+            vertical_sep(
+                lists:zip(Es, AddEmptyLines));
         generator ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:generator_pattern(Node), Ctxt1),
-            D2 = lay(erl_syntax:generator_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:generator_pattern(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:generator_body(Node), Ctxt1),
             par([D1, beside(text("<- "), D2)], Ctxt1#ctxt.break_indent);
         binary_generator ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
-            D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:binary_generator_pattern(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:binary_generator_body(Node), Ctxt1),
             par([D1, beside(text("<= "), D2)], Ctxt1#ctxt.break_indent);
         implicit_fun ->
-            D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
+            D =
+                lay(
+                    erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
             beside(lay_text_float("fun "), D);
         list_comp ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:list_comp_template(Node), Ctxt1),
-            D2 = lay_items(erl_syntax:list_comp_body(Node), Ctxt1, fun lay/2),
+            D1 =
+                lay(
+                    erl_syntax:list_comp_template(Node), Ctxt1),
+            D2 =
+                lay_items(
+                    erl_syntax:list_comp_body(Node), Ctxt1, fun lay/2),
             beside(lay_text_float("["),
                    par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float("]")))]));
         binary_comp ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:binary_comp_template(Node), Ctxt1),
-            D2 = lay_items(erl_syntax:binary_comp_body(Node), Ctxt1, fun lay/2),
+            D1 =
+                lay(
+                    erl_syntax:binary_comp_template(Node), Ctxt1),
+            D2 =
+                lay_items(
+                    erl_syntax:binary_comp_body(Node), Ctxt1, fun lay/2),
             beside(lay_text_float("<< "),
                    par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float(" >>")))]));
         macro ->
@@ -529,11 +621,15 @@ lay_no_comments(Node, Ctxt) ->
             D1 = beside(lay_text_float("?"), D),
             maybe_parentheses(D1, 0, Ctxt1);
         parentheses ->
-            D = lay(erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
+            D =
+                lay(
+                    erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
             lay_parentheses(D, Ctxt);
         receive_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay_clauses(erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
+            D1 =
+                lay_clauses(
+                    erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
             D2 =
                 case erl_syntax:receive_expr_timeout(Node) of
                     none ->
@@ -541,9 +637,8 @@ lay_no_comments(Node, Ctxt) ->
                     T ->
                         D3 = lay(T, Ctxt1),
                         D4 =
-                            lay_clause_expressions(erl_syntax:receive_expr_action(Node),
-                                                   Ctxt1,
-                                                   fun lay/2),
+                            lay_clause_expressions(
+                                erl_syntax:receive_expr_action(Node), Ctxt1, fun lay/2),
                         vertical([D1,
                                   follow(lay_text_float("after"),
                                          append_clause_body(D4, D3, Ctxt1),
@@ -552,17 +647,24 @@ lay_no_comments(Node, Ctxt) ->
             sep([text("receive"), nest(Ctxt1#ctxt.break_indent, D2), text("end")]);
         record_access ->
             {PrecL, Prec, PrecR} = inop_prec('#'),
-            D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
+            D1 =
+                lay(
+                    erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
             D2 =
                 beside(lay_text_float("."),
-                       lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
+                       lay(
+                           erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
             T = erl_syntax:record_access_type(Node),
             D3 = beside(beside(lay_text_float("#"), lay(T, reset_prec(Ctxt))), D2),
             maybe_parentheses(beside(D1, D3), Prec, Ctxt);
         record_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
-            D2 = lay_items(erl_syntax:record_expr_fields(Node), Ctxt1, fun lay/2),
+            D1 =
+                lay(
+                    erl_syntax:record_expr_type(Node), Ctxt1),
+            D2 =
+                lay_items(
+                    erl_syntax:record_expr_fields(Node), Ctxt1, fun lay/2),
             D3 =
                 beside(beside(lay_text_float("#"), D1),
                        beside(text("{"), beside(D2, lay_text_float("}")))),
@@ -570,7 +672,9 @@ lay_no_comments(Node, Ctxt) ->
             lay_expr_argument(Arg, D3, Ctxt);
         record_field ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:record_field_name(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:record_field_name(Node), Ctxt1),
             case erl_syntax:record_field_value(Node) of
                 none ->
                     D1;
@@ -579,13 +683,19 @@ lay_no_comments(Node, Ctxt) ->
             end;
         record_index_expr ->
             {Prec, PrecR} = preop_prec('#'),
-            D1 = lay(erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
-            D2 = lay(erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
+            D2 =
+                lay(
+                    erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
             D3 = beside(beside(lay_text_float("#"), D1), beside(lay_text_float("."), D2)),
             maybe_parentheses(D3, Prec, Ctxt);
         map_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay_items(erl_syntax:map_expr_fields(Node), Ctxt1, fun lay/2),
+            D1 =
+                lay_items(
+                    erl_syntax:map_expr_fields(Node), Ctxt1, fun lay/2),
             D2 = beside(text("#{"), beside(D1, lay_text_float("}"))),
             Arg = erl_syntax:map_expr_argument(Node),
             lay_expr_argument(Arg, D2, Ctxt);
@@ -599,21 +709,32 @@ lay_no_comments(Node, Ctxt) ->
             lay_type_exact(Name, Value, Ctxt);
         size_qualifier ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 = lay(erl_syntax:size_qualifier_body(Node), Ctxt1),
-            D2 = lay(erl_syntax:size_qualifier_argument(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:size_qualifier_body(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:size_qualifier_argument(Node), Ctxt1),
             beside(D1, beside(text(":"), D2));
         text ->
-            text(erl_syntax:text_string(Node));
+            text(
+                erl_syntax:text_string(Node));
         typed_record_field ->
             {_, Prec, _} = type_inop_prec('::'),
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:typed_record_field_body(Node), Ctxt1),
-            D2 = lay(erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
+            D1 =
+                lay(
+                    erl_syntax:typed_record_field_body(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
             D3 = lay_double_colon(D1, D2, Ctxt1, without_preceding_space),
             maybe_parentheses(D3, Prec, Ctxt);
         try_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D0 = lay_clause_expressions(erl_syntax:try_expr_body(Node), Ctxt1, fun lay/2),
+            D0 =
+                lay_clause_expressions(
+                    erl_syntax:try_expr_body(Node), Ctxt1, fun lay/2),
             D1 =
                 case erl_syntax:try_expr_clauses(Node) of
                     [] ->
@@ -655,8 +776,12 @@ lay_no_comments(Node, Ctxt) ->
         %%
         annotated_type ->
             {_, Prec, _} = type_inop_prec('::'),
-            D1 = lay(erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
-            D2 = lay(erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
+            D1 =
+                lay(
+                    erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
+            D2 =
+                lay(
+                    erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
             D3 = lay_double_colon(D1, D2, Ctxt, with_preceding_space),
             maybe_parentheses(D3, Prec, Ctxt);
         type_application ->
@@ -697,9 +822,13 @@ lay_no_comments(Node, Ctxt) ->
             text("fun()");
         constrained_function_type ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:constrained_function_type_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:constrained_function_type_body(Node), Ctxt1),
             Ctxt2 = Ctxt1#ctxt{clause = undefined},
-            D2 = lay(erl_syntax:constrained_function_type_argument(Node), Ctxt2),
+            D2 =
+                lay(
+                    erl_syntax:constrained_function_type_argument(Node), Ctxt2),
             beside(D1, beside(lay_text_float(" when "), D2));
         function_type ->
             {Before, After} =
@@ -718,7 +847,9 @@ lay_no_comments(Node, Ctxt) ->
                         As = lay_items(Arguments, Ctxt1, fun lay/2),
                         beside(text("("), beside(As, lay_text_float(")")))
                 end,
-            D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:function_type_return(Node), Ctxt1),
             beside(lay_text_float(Before),
                    sep([beside(D1, lay_text_float(" ->")),
                         nest(Ctxt#ctxt.break_indent, beside(D2, lay_text_float(After)))]));
@@ -757,20 +888,33 @@ lay_no_comments(Node, Ctxt) ->
             lay_type_exact(Name, Value, Ctxt);
         integer_range_type ->
             {PrecL, Prec, PrecR} = type_inop_prec('..'),
-            D1 = lay(erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
-            D2 = lay(erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                lay(
+                    erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
             D3 = beside(D1, beside(text(".."), D2)),
             maybe_parentheses(D3, Prec, Ctxt);
         record_type ->
             {Prec, _PrecR} = type_preop_prec('#'),
-            D1 = beside(text("#"), lay(erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
-            Es = lay_items(erl_syntax:record_type_fields(Node), reset_prec(Ctxt), fun lay/2),
+            D1 =
+                beside(text("#"),
+                       lay(
+                           erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
+            Es =
+                lay_items(
+                    erl_syntax:record_type_fields(Node), reset_prec(Ctxt), fun lay/2),
             D2 = beside(D1, beside(text("{"), beside(Es, lay_text_float("}")))),
             maybe_parentheses(D2, Prec, Ctxt);
         record_type_field ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:record_type_field_name(Node), Ctxt1),
-            D2 = lay(erl_syntax:record_type_field_type(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:record_type_field_name(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:record_type_field_type(Node), Ctxt1),
             lay_double_colon(D1, D2, Ctxt1, without_preceding_space);
         tuple_type ->
             case erl_syntax:tuple_type_elements(Node) of
@@ -783,15 +927,17 @@ lay_no_comments(Node, Ctxt) ->
         type_union ->
             {_, Prec, PrecR} = type_inop_prec('|'),
             Es =
-                lay_items(erl_syntax:type_union_types(Node),
-                          lay_text_float(" |"),
-                          set_prec(Ctxt, PrecR),
-                          fun lay/2),
+                lay_items(
+                    erl_syntax:type_union_types(Node),
+                    lay_text_float(" |"),
+                    set_prec(Ctxt, PrecR),
+                    fun lay/2),
             maybe_parentheses(Es, Prec, Ctxt);
         user_type_application ->
-            lay_application(erl_syntax:user_type_application_name(Node),
-                            erl_syntax:user_type_application_arguments(Node),
-                            Ctxt)
+            lay_application(
+                erl_syntax:user_type_application_name(Node),
+                erl_syntax:user_type_application_arguments(Node),
+                Ctxt)
     end.
 
 attribute_name(Node) ->
@@ -840,7 +986,8 @@ unfold_function_name(Tuple) ->
     end.
 
 concrete_dodging_macros(Nodes) ->
-    undodge_macros(erl_syntax:concrete(dodge_macros(Nodes))).
+    undodge_macros(
+        erl_syntax:concrete(dodge_macros(Nodes))).
 
 %% Macros are not handled well.
 dodge_macros(Type) ->
@@ -866,7 +1013,9 @@ undodge_macro(T) ->
         atom ->
             case get_node_text(T) of
                 "?" ->
-                    erl_syntax:macro(erl_syntax:variable(erl_syntax:atom_name(T)));
+                    erl_syntax:macro(
+                        erl_syntax:variable(
+                            erl_syntax:atom_name(T)));
                 _ ->
                     T
             end;
@@ -1038,7 +1187,9 @@ lay_error_info({L, M, T} = T0, Ctxt) when is_integer(L), is_atom(M) ->
         S when is_list(S) ->
             case L > 0 of
                 true ->
-                    beside(text(io_lib:format("~w: ", [L])), text(S));
+                    beside(text(
+                               io_lib:format("~w: ", [L])),
+                           text(S));
                 _ ->
                     text(S)
             end;
@@ -1049,7 +1200,8 @@ lay_error_info(T, Ctxt) ->
     lay_concrete(T, Ctxt).
 
 lay_concrete(T, Ctxt) ->
-    lay(erl_syntax:abstract(T), Ctxt).
+    lay(
+        erl_syntax:abstract(T), Ctxt).
 
 lay_type_assoc(Name, Value, Ctxt) ->
     lay_type_par_text(Name, Value, "=>", Ctxt).
@@ -1067,15 +1219,35 @@ lay_application(Name, Arguments, Ctxt) ->
     case erl_syntax:type(Name) of
         macro ->
             [Arg | Args] = Arguments,
-            MacroVar = erl_syntax:variable([$? | atom_to_list(erl_syntax:variable_name(Arg))]),
+            MacroVar =
+                erl_syntax:variable([$? | atom_to_list(
+                                              erl_syntax:variable_name(Arg))]),
             lay_application(MacroVar, Args, Ctxt);
         _ ->
-            {PrecL, Prec} = func_prec(), %
-            D1 = lay(Name, set_prec(Ctxt, PrecL)),
-            As = lay_items(Arguments, reset_prec(Ctxt), fun lay/2),
-            D = beside(D1, beside(text("("), beside(As, lay_text_float(")")))),
+            {PrecL, Prec} = func_prec(),
+            DName = beside(lay(Name, set_prec(Ctxt, PrecL)), text("(")),
+            DArgs = beside(lay_items(Arguments, reset_prec(Ctxt), fun lay/2), lay_text_float(")")),
+            D =
+                case is_qualified_function_composition(Arguments) of
+                    true ->
+                        vertical([DName, nest(Ctxt#ctxt.break_indent, DArgs)]);
+                    _ ->
+                        beside(DName, DArgs)
+                end,
             maybe_parentheses(D, Prec, Ctxt)
     end.
+
+%% @doc Is this a function composition where the first element is a fully-qualified name.
+%%      i.e. something like my_fun(another_module:another_func(...))
+%%      The idea in this scenario is to indent that with the heuristic thinking that such
+%%      a function composition will result in a very long line.
+is_qualified_function_composition([]) ->
+    false;
+is_qualified_function_composition([FirstArg | _]) ->
+    erl_syntax:type(FirstArg) == application andalso
+        module_qualifier ==
+            erl_syntax:type(
+                erl_syntax:application_operator(FirstArg)).
 
 seq([H], _Separator, Ctxt, Fun) ->
     [Fun(H, Ctxt)];

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -88,9 +88,7 @@ format(Node, EmptyLines, Options) ->
                 []
         end,
     PreFormatted = prettypr:format(layout(Node, FinalEmptyLines, Options), W, L),
-    Formatted =
-        remove_tabs(
-            unicode:characters_to_binary(PreFormatted, E)),
+    Formatted = remove_tabs(unicode:characters_to_binary(PreFormatted, E)),
     remove_trailing_spaces(Formatted).
 
 %% @doc Initialize the formatter and generate a state that will be passed in when
@@ -147,11 +145,8 @@ lay(Node, Ctxt) ->
     case erl_syntax:has_comments(Node) of
         true ->
             D1 = lay_no_comments(Node, Ctxt),
-            D2 =
-                lay_postcomments(
-                    erl_syntax:get_postcomments(Node), D1),
-            lay_precomments(
-                erl_syntax:get_precomments(Node), D2);
+            D2 = lay_postcomments(erl_syntax:get_postcomments(Node), D1),
+            lay_precomments(erl_syntax:get_precomments(Node), D2);
         false ->
             lay_no_comments(Node, Ctxt)
     end.
@@ -171,9 +166,7 @@ lay_postcomments(Cs, D) ->
 %% Format (including padding, if `Pad' is `true', otherwise not)
 %% and stack the listed comments above each other.
 stack_comments([C | Cs], Pad) ->
-    D =
-        stack_comment_lines(
-            erl_syntax:comment_text(C)),
+    D = stack_comment_lines(erl_syntax:comment_text(C)),
     D1 =
         case Pad of
             true ->
@@ -216,8 +209,7 @@ lay_no_comments(Node, Ctxt) ->
     case erl_syntax:type(Node) of
         %% We list literals and other common cases first.
         variable ->
-            text(
-                erl_syntax:variable_literal(Node));
+            text(erl_syntax:variable_literal(Node));
         atom ->
             text(tidy_atom(Node, Ctxt));
         integer ->
@@ -231,16 +223,12 @@ lay_no_comments(Node, Ctxt) ->
         nil ->
             text("[]");
         tuple ->
-            Es =
-                lay_items(
-                    erl_syntax:tuple_elements(Node), reset_prec(Ctxt), fun lay/2),
+            Es = lay_items(erl_syntax:tuple_elements(Node), reset_prec(Ctxt), fun lay/2),
             beside(lay_text_float("{"), beside(Es, lay_text_float("}")));
         list ->
             Ctxt1 = reset_prec(Ctxt),
             Node1 = erl_syntax:compact_list(Node),
-            D1 =
-                lay_items(
-                    erl_syntax:list_prefix(Node1), Ctxt1, fun lay/2),
+            D1 = lay_items(erl_syntax:list_prefix(Node1), Ctxt1, fun lay/2),
             D =
                 case erl_syntax:list_suffix(Node1) of
                     none ->
@@ -252,25 +240,19 @@ lay_no_comments(Node, Ctxt) ->
                 end,
             beside(lay_text_float("["), D);
         operator ->
-            lay_text_float(
-                erl_syntax:operator_literal(Node));
+            lay_text_float(erl_syntax:operator_literal(Node));
         infix_expr ->
             Operator = erl_syntax:infix_expr_operator(Node),
             {PrecL, Prec, PrecR} =
                 case erl_syntax:type(Operator) of
                     operator ->
-                        inop_prec(
-                            erl_syntax:operator_name(Operator));
+                        inop_prec(erl_syntax:operator_name(Operator));
                     _ ->
                         {0, 0, 0}
                 end,
-            D1 =
-                lay(
-                    erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
+            D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
             D2 = lay(Operator, reset_prec(Ctxt)),
-            D3 =
-                lay(
-                    erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
+            D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
             D4 = par([D1, D2, D3], Ctxt#ctxt.break_indent),
             maybe_parentheses(D4, Prec, Ctxt);
         prefix_expr ->
@@ -284,9 +266,7 @@ lay_no_comments(Node, Ctxt) ->
                         {{0, 0}, any}
                 end,
             D1 = lay(Operator, reset_prec(Ctxt)),
-            D2 =
-                lay(
-                    erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
+            D2 = lay(erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
             D3 =
                 case Name of
                     '+' ->
@@ -298,18 +278,13 @@ lay_no_comments(Node, Ctxt) ->
                 end,
             maybe_parentheses(D3, Prec, Ctxt);
         application ->
-            lay_application(
-                erl_syntax:application_operator(Node),
-                erl_syntax:application_arguments(Node),
-                Ctxt);
+            lay_application(erl_syntax:application_operator(Node),
+                            erl_syntax:application_arguments(Node),
+                            Ctxt);
         match_expr ->
             {PrecL, Prec, PrecR} = inop_prec('='),
-            D1 =
-                lay(
-                    erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
-            D2 =
-                lay(
-                    erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D1 = lay(erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
             D3 = sep([beside(D1, lay_text_float(" =")), nest(Ctxt#ctxt.break_indent, D2)]),
             maybe_parentheses(D3, Prec, Ctxt);
         underscore ->
@@ -317,9 +292,7 @@ lay_no_comments(Node, Ctxt) ->
         clause ->
             %% The style used for a clause depends on its context
             Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
-            D1 =
-                lay_items(
-                    erl_syntax:clause_patterns(Node), Ctxt1, fun lay/2),
+            D1 = lay_items(erl_syntax:clause_patterns(Node), Ctxt1, fun lay/2),
             D2 =
                 case erl_syntax:clause_guard(Node) of
                     none ->
@@ -327,9 +300,7 @@ lay_no_comments(Node, Ctxt) ->
                     G ->
                         lay(G, Ctxt1)
                 end,
-            D3 =
-                lay_clause_expressions(
-                    erl_syntax:clause_body(Node), Ctxt1, fun lay/2),
+            D3 = lay_clause_expressions(erl_syntax:clause_body(Node), Ctxt1, fun lay/2),
             case Ctxt#ctxt.clause of
                 fun_expr ->
                     make_fun_clause(D1, D2, D3, Ctxt);
@@ -352,66 +323,42 @@ lay_no_comments(Node, Ctxt) ->
             %% Comments on the name itself will be repeated for each
             %% clause, but that seems to be the best way to handle it.
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:function_name(Node), Ctxt1),
-            D2 =
-                lay_clauses(
-                    erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
+            D1 = lay(erl_syntax:function_name(Node), Ctxt1),
+            D2 = lay_clauses(erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
             beside(D2, lay_text_float("."));
         case_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:case_expr_argument(Node), Ctxt1),
-            D2 =
-                lay_clauses(
-                    erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
+            D1 = lay(erl_syntax:case_expr_argument(Node), Ctxt1),
+            D2 = lay_clauses(erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
             sep([par([follow(text("case"), D1, Ctxt1#ctxt.break_indent), text("of")],
                      Ctxt1#ctxt.break_indent),
                  nest(Ctxt1#ctxt.break_indent, D2),
                  text("end")]);
         if_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D =
-                lay_clauses(
-                    erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
+            D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
             sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
         fun_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            Clauses =
-                lay_clauses(
-                    erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
+            Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
             lay_fun_sep(Clauses, Ctxt1);
         named_fun_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:named_fun_expr_name(Node), Ctxt1),
-            Clauses =
-                lay_clauses(
-                    erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
+            D1 = lay(erl_syntax:named_fun_expr_name(Node), Ctxt1),
+            Clauses = lay_clauses(erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
             lay_fun_sep(Clauses, Ctxt1);
         module_qualifier ->
             {PrecL, _Prec, PrecR} = inop_prec(':'),
-            D1 =
-                lay(
-                    erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
-            D2 =
-                lay(
-                    erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
+            D1 = lay(erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
             beside(D1, beside(text(":"), D2));
         %%
         %% The rest is in alphabetical order (except map and types)
         %%
         arity_qualifier ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:arity_qualifier_body(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:arity_qualifier_argument(Node), Ctxt1),
+            D1 = lay(erl_syntax:arity_qualifier_body(Node), Ctxt1),
+            D2 = lay(erl_syntax:arity_qualifier_argument(Node), Ctxt1),
             beside(D1, beside(text("/"), D2));
         attribute ->
             %% The attribute name and arguments are formatted similar to
@@ -481,15 +428,11 @@ lay_no_comments(Node, Ctxt) ->
             beside(lay_text_float("-"), beside(D, lay_text_float(".")));
         binary ->
             Ctxt1 = reset_prec(Ctxt),
-            Es =
-                lay_items(
-                    erl_syntax:binary_fields(Node), Ctxt1, fun lay/2),
+            Es = lay_items(erl_syntax:binary_fields(Node), Ctxt1, fun lay/2),
             beside(lay_text_float("<<"), beside(Es, lay_text_float(">>")));
         binary_field ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 =
-                lay(
-                    erl_syntax:binary_field_body(Node), Ctxt1),
+            D1 = lay(erl_syntax:binary_field_body(Node), Ctxt1),
             D2 =
                 case erl_syntax:binary_field_types(Node) of
                     [] ->
@@ -500,25 +443,17 @@ lay_no_comments(Node, Ctxt) ->
             beside(D1, D2);
         block_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            Es =
-                lay_clause_expressions(
-                    erl_syntax:block_expr_body(Node), Ctxt1, fun lay/2),
+            Es = lay_clause_expressions(erl_syntax:block_expr_body(Node), Ctxt1, fun lay/2),
             sep([text("begin"), nest(Ctxt1#ctxt.break_indent, Es), text("end")]);
         catch_expr ->
             {Prec, PrecR} = preop_prec('catch'),
-            D =
-                lay(
-                    erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
             D1 = follow(text("catch"), D, Ctxt#ctxt.break_indent),
             maybe_parentheses(D1, Prec, Ctxt);
         class_qualifier ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 =
-                lay(
-                    erl_syntax:class_qualifier_argument(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:class_qualifier_body(Node), Ctxt1),
+            D1 = lay(erl_syntax:class_qualifier_argument(Node), Ctxt1),
+            D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
             Stacktrace = erl_syntax:class_qualifier_stacktrace(Node),
             case erl_syntax:variable_name(Stacktrace) of
                 '_' ->
@@ -528,9 +463,7 @@ lay_no_comments(Node, Ctxt) ->
                     beside(D1, beside(beside(text(":"), D2), beside(text(":"), D3)))
             end;
         comment ->
-            D =
-                stack_comment_lines(
-                    erl_syntax:comment_text(Node)),
+            D = stack_comment_lines(erl_syntax:comment_text(Node)),
             %% Default padding for standalone comments is empty.
             case erl_syntax:comment_padding(Node) of
                 none ->
@@ -539,13 +472,11 @@ lay_no_comments(Node, Ctxt) ->
                     floating(break(beside(text(spaces(P)), D)))
             end;
         conjunction ->
-            lay_items(
-                erl_syntax:conjunction_body(Node), reset_prec(Ctxt), fun lay/2);
+            lay_items(erl_syntax:conjunction_body(Node), reset_prec(Ctxt), fun lay/2);
         disjunction ->
             %% For clarity, we don't paragraph-format
             %% disjunctions; only conjunctions (see above).
-            sep(seq(
-                    erl_syntax:disjunction_body(Node),
+            sep(seq(erl_syntax:disjunction_body(Node),
                     lay_text_float(";"),
                     reset_prec(Ctxt),
                     fun lay/2));
@@ -555,55 +486,32 @@ lay_no_comments(Node, Ctxt) ->
         eof_marker ->
             empty();
         form_list ->
-            Es =
-                seq(
-                    erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
-            AddEmptyLines =
-                empty_lines_to_add(
-                    erl_syntax:form_list_elements(Node), Ctxt),
-            vertical_sep(
-                lists:zip(Es, AddEmptyLines));
+            Es = seq(erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
+            AddEmptyLines = empty_lines_to_add(erl_syntax:form_list_elements(Node), Ctxt),
+            vertical_sep(lists:zip(Es, AddEmptyLines));
         generator ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:generator_pattern(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:generator_body(Node), Ctxt1),
+            D1 = lay(erl_syntax:generator_pattern(Node), Ctxt1),
+            D2 = lay(erl_syntax:generator_body(Node), Ctxt1),
             par([D1, beside(text("<- "), D2)], Ctxt1#ctxt.break_indent);
         binary_generator ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:binary_generator_pattern(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:binary_generator_body(Node), Ctxt1),
+            D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
+            D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
             par([D1, beside(text("<= "), D2)], Ctxt1#ctxt.break_indent);
         implicit_fun ->
-            D =
-                lay(
-                    erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
+            D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
             beside(lay_text_float("fun "), D);
         list_comp ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:list_comp_template(Node), Ctxt1),
-            D2 =
-                lay_items(
-                    erl_syntax:list_comp_body(Node), Ctxt1, fun lay/2),
+            D1 = lay(erl_syntax:list_comp_template(Node), Ctxt1),
+            D2 = lay_items(erl_syntax:list_comp_body(Node), Ctxt1, fun lay/2),
             beside(lay_text_float("["),
                    par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float("]")))]));
         binary_comp ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:binary_comp_template(Node), Ctxt1),
-            D2 =
-                lay_items(
-                    erl_syntax:binary_comp_body(Node), Ctxt1, fun lay/2),
+            D1 = lay(erl_syntax:binary_comp_template(Node), Ctxt1),
+            D2 = lay_items(erl_syntax:binary_comp_body(Node), Ctxt1, fun lay/2),
             beside(lay_text_float("<< "),
                    par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float(" >>")))]));
         macro ->
@@ -621,15 +529,11 @@ lay_no_comments(Node, Ctxt) ->
             D1 = beside(lay_text_float("?"), D),
             maybe_parentheses(D1, 0, Ctxt1);
         parentheses ->
-            D =
-                lay(
-                    erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
+            D = lay(erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
             lay_parentheses(D, Ctxt);
         receive_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay_clauses(
-                    erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
+            D1 = lay_clauses(erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
             D2 =
                 case erl_syntax:receive_expr_timeout(Node) of
                     none ->
@@ -637,8 +541,9 @@ lay_no_comments(Node, Ctxt) ->
                     T ->
                         D3 = lay(T, Ctxt1),
                         D4 =
-                            lay_clause_expressions(
-                                erl_syntax:receive_expr_action(Node), Ctxt1, fun lay/2),
+                            lay_clause_expressions(erl_syntax:receive_expr_action(Node),
+                                                   Ctxt1,
+                                                   fun lay/2),
                         vertical([D1,
                                   follow(lay_text_float("after"),
                                          append_clause_body(D4, D3, Ctxt1),
@@ -647,24 +552,17 @@ lay_no_comments(Node, Ctxt) ->
             sep([text("receive"), nest(Ctxt1#ctxt.break_indent, D2), text("end")]);
         record_access ->
             {PrecL, Prec, PrecR} = inop_prec('#'),
-            D1 =
-                lay(
-                    erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
+            D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
             D2 =
                 beside(lay_text_float("."),
-                       lay(
-                           erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
+                       lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
             T = erl_syntax:record_access_type(Node),
             D3 = beside(beside(lay_text_float("#"), lay(T, reset_prec(Ctxt))), D2),
             maybe_parentheses(beside(D1, D3), Prec, Ctxt);
         record_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:record_expr_type(Node), Ctxt1),
-            D2 =
-                lay_items(
-                    erl_syntax:record_expr_fields(Node), Ctxt1, fun lay/2),
+            D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
+            D2 = lay_items(erl_syntax:record_expr_fields(Node), Ctxt1, fun lay/2),
             D3 =
                 beside(beside(lay_text_float("#"), D1),
                        beside(text("{"), beside(D2, lay_text_float("}")))),
@@ -672,9 +570,7 @@ lay_no_comments(Node, Ctxt) ->
             lay_expr_argument(Arg, D3, Ctxt);
         record_field ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:record_field_name(Node), Ctxt1),
+            D1 = lay(erl_syntax:record_field_name(Node), Ctxt1),
             case erl_syntax:record_field_value(Node) of
                 none ->
                     D1;
@@ -683,19 +579,13 @@ lay_no_comments(Node, Ctxt) ->
             end;
         record_index_expr ->
             {Prec, PrecR} = preop_prec('#'),
-            D1 =
-                lay(
-                    erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
-            D2 =
-                lay(
-                    erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
+            D1 = lay(erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
+            D2 = lay(erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
             D3 = beside(beside(lay_text_float("#"), D1), beside(lay_text_float("."), D2)),
             maybe_parentheses(D3, Prec, Ctxt);
         map_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay_items(
-                    erl_syntax:map_expr_fields(Node), Ctxt1, fun lay/2),
+            D1 = lay_items(erl_syntax:map_expr_fields(Node), Ctxt1, fun lay/2),
             D2 = beside(text("#{"), beside(D1, lay_text_float("}"))),
             Arg = erl_syntax:map_expr_argument(Node),
             lay_expr_argument(Arg, D2, Ctxt);
@@ -709,32 +599,21 @@ lay_no_comments(Node, Ctxt) ->
             lay_type_exact(Name, Value, Ctxt);
         size_qualifier ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 =
-                lay(
-                    erl_syntax:size_qualifier_body(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:size_qualifier_argument(Node), Ctxt1),
+            D1 = lay(erl_syntax:size_qualifier_body(Node), Ctxt1),
+            D2 = lay(erl_syntax:size_qualifier_argument(Node), Ctxt1),
             beside(D1, beside(text(":"), D2));
         text ->
-            text(
-                erl_syntax:text_string(Node));
+            text(erl_syntax:text_string(Node));
         typed_record_field ->
             {_, Prec, _} = type_inop_prec('::'),
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:typed_record_field_body(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
+            D1 = lay(erl_syntax:typed_record_field_body(Node), Ctxt1),
+            D2 = lay(erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
             D3 = lay_double_colon(D1, D2, Ctxt1, without_preceding_space),
             maybe_parentheses(D3, Prec, Ctxt);
         try_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D0 =
-                lay_clause_expressions(
-                    erl_syntax:try_expr_body(Node), Ctxt1, fun lay/2),
+            D0 = lay_clause_expressions(erl_syntax:try_expr_body(Node), Ctxt1, fun lay/2),
             D1 =
                 case erl_syntax:try_expr_clauses(Node) of
                     [] ->
@@ -776,12 +655,8 @@ lay_no_comments(Node, Ctxt) ->
         %%
         annotated_type ->
             {_, Prec, _} = type_inop_prec('::'),
-            D1 =
-                lay(
-                    erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
-            D2 =
-                lay(
-                    erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
+            D1 = lay(erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
+            D2 = lay(erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
             D3 = lay_double_colon(D1, D2, Ctxt, with_preceding_space),
             maybe_parentheses(D3, Prec, Ctxt);
         type_application ->
@@ -822,13 +697,9 @@ lay_no_comments(Node, Ctxt) ->
             text("fun()");
         constrained_function_type ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:constrained_function_type_body(Node), Ctxt1),
+            D1 = lay(erl_syntax:constrained_function_type_body(Node), Ctxt1),
             Ctxt2 = Ctxt1#ctxt{clause = undefined},
-            D2 =
-                lay(
-                    erl_syntax:constrained_function_type_argument(Node), Ctxt2),
+            D2 = lay(erl_syntax:constrained_function_type_argument(Node), Ctxt2),
             beside(D1, beside(lay_text_float(" when "), D2));
         function_type ->
             {Before, After} =
@@ -847,9 +718,7 @@ lay_no_comments(Node, Ctxt) ->
                         As = lay_items(Arguments, Ctxt1, fun lay/2),
                         beside(text("("), beside(As, lay_text_float(")")))
                 end,
-            D2 =
-                lay(
-                    erl_syntax:function_type_return(Node), Ctxt1),
+            D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
             beside(lay_text_float(Before),
                    sep([beside(D1, lay_text_float(" ->")),
                         nest(Ctxt#ctxt.break_indent, beside(D2, lay_text_float(After)))]));
@@ -888,33 +757,20 @@ lay_no_comments(Node, Ctxt) ->
             lay_type_exact(Name, Value, Ctxt);
         integer_range_type ->
             {PrecL, Prec, PrecR} = type_inop_prec('..'),
-            D1 =
-                lay(
-                    erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
-            D2 =
-                lay(
-                    erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
+            D1 = lay(erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
+            D2 = lay(erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
             D3 = beside(D1, beside(text(".."), D2)),
             maybe_parentheses(D3, Prec, Ctxt);
         record_type ->
             {Prec, _PrecR} = type_preop_prec('#'),
-            D1 =
-                beside(text("#"),
-                       lay(
-                           erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
-            Es =
-                lay_items(
-                    erl_syntax:record_type_fields(Node), reset_prec(Ctxt), fun lay/2),
+            D1 = beside(text("#"), lay(erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
+            Es = lay_items(erl_syntax:record_type_fields(Node), reset_prec(Ctxt), fun lay/2),
             D2 = beside(D1, beside(text("{"), beside(Es, lay_text_float("}")))),
             maybe_parentheses(D2, Prec, Ctxt);
         record_type_field ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 =
-                lay(
-                    erl_syntax:record_type_field_name(Node), Ctxt1),
-            D2 =
-                lay(
-                    erl_syntax:record_type_field_type(Node), Ctxt1),
+            D1 = lay(erl_syntax:record_type_field_name(Node), Ctxt1),
+            D2 = lay(erl_syntax:record_type_field_type(Node), Ctxt1),
             lay_double_colon(D1, D2, Ctxt1, without_preceding_space);
         tuple_type ->
             case erl_syntax:tuple_type_elements(Node) of
@@ -927,17 +783,15 @@ lay_no_comments(Node, Ctxt) ->
         type_union ->
             {_, Prec, PrecR} = type_inop_prec('|'),
             Es =
-                lay_items(
-                    erl_syntax:type_union_types(Node),
-                    lay_text_float(" |"),
-                    set_prec(Ctxt, PrecR),
-                    fun lay/2),
+                lay_items(erl_syntax:type_union_types(Node),
+                          lay_text_float(" |"),
+                          set_prec(Ctxt, PrecR),
+                          fun lay/2),
             maybe_parentheses(Es, Prec, Ctxt);
         user_type_application ->
-            lay_application(
-                erl_syntax:user_type_application_name(Node),
-                erl_syntax:user_type_application_arguments(Node),
-                Ctxt)
+            lay_application(erl_syntax:user_type_application_name(Node),
+                            erl_syntax:user_type_application_arguments(Node),
+                            Ctxt)
     end.
 
 attribute_name(Node) ->
@@ -986,8 +840,7 @@ unfold_function_name(Tuple) ->
     end.
 
 concrete_dodging_macros(Nodes) ->
-    undodge_macros(
-        erl_syntax:concrete(dodge_macros(Nodes))).
+    undodge_macros(erl_syntax:concrete(dodge_macros(Nodes))).
 
 %% Macros are not handled well.
 dodge_macros(Type) ->
@@ -1187,9 +1040,7 @@ lay_error_info({L, M, T} = T0, Ctxt) when is_integer(L), is_atom(M) ->
         S when is_list(S) ->
             case L > 0 of
                 true ->
-                    beside(text(
-                               io_lib:format("~w: ", [L])),
-                           text(S));
+                    beside(text(io_lib:format("~w: ", [L])), text(S));
                 _ ->
                     text(S)
             end;
@@ -1200,8 +1051,7 @@ lay_error_info(T, Ctxt) ->
     lay_concrete(T, Ctxt).
 
 lay_concrete(T, Ctxt) ->
-    lay(
-        erl_syntax:abstract(T), Ctxt).
+    lay(erl_syntax:abstract(T), Ctxt).
 
 lay_type_assoc(Name, Value, Ctxt) ->
     lay_type_par_text(Name, Value, "=>", Ctxt).
@@ -1219,16 +1069,14 @@ lay_application(Name, Arguments, Ctxt) ->
     case erl_syntax:type(Name) of
         macro ->
             [Arg | Args] = Arguments,
-            MacroVar =
-                erl_syntax:variable([$? | atom_to_list(
-                                              erl_syntax:variable_name(Arg))]),
+            MacroVar = erl_syntax:variable([$? | atom_to_list(erl_syntax:variable_name(Arg))]),
             lay_application(MacroVar, Args, Ctxt);
         _ ->
             {PrecL, Prec} = func_prec(),
             DName = beside(lay(Name, set_prec(Ctxt, PrecL)), text("(")),
             DArgs = beside(lay_items(Arguments, reset_prec(Ctxt), fun lay/2), lay_text_float(")")),
             D =
-                case is_qualified_function_composition(Arguments) of
+                case is_qualified_function_composition(Name, Arguments) of
                     true ->
                         vertical([DName, nest(Ctxt#ctxt.break_indent, DArgs)]);
                     _ ->
@@ -1237,17 +1085,18 @@ lay_application(Name, Arguments, Ctxt) ->
             maybe_parentheses(D, Prec, Ctxt)
     end.
 
-%% @doc Is this a function composition where the first element is a fully-qualified name.
-%%      i.e. something like my_fun(another_module:another_func(...))
+%% @doc Is this a function composition of two fully-qualified names.
+%%      i.e. something like a_module:a_fun(another_module:another_func(...))
 %%      The idea in this scenario is to indent that with the heuristic thinking that such
 %%      a function composition will result in a very long line.
-is_qualified_function_composition([]) ->
+is_qualified_function_composition(_, []) ->
     false;
-is_qualified_function_composition([FirstArg | _]) ->
-    erl_syntax:type(FirstArg) == application andalso
-        module_qualifier ==
-            erl_syntax:type(
-                erl_syntax:application_operator(FirstArg)).
+is_qualified_function_composition(Outside, [FirstArg | _]) ->
+    module_qualifier == erl_syntax:type(Outside) andalso
+        erl_syntax:type(FirstArg) == application andalso
+            module_qualifier ==
+                erl_syntax:type(
+                    erl_syntax:application_operator(FirstArg)).
 
 seq([H], _Separator, Ctxt, Fun) ->
     [Fun(H, Ctxt)];

--- a/src/formatters/erlfmt_formatter.erl
+++ b/src/formatters/erlfmt_formatter.erl
@@ -32,7 +32,9 @@ format_file(File, nostate, OptionsMap) ->
             OutputDir ->
                 %% We understand output dirs differently than erlfmt.
                 %% We use relative subpaths.
-                OFile = filename:join(filename:absname(OutputDir), File),
+                OFile =
+                    filename:join(
+                        filename:absname(OutputDir), File),
                 {{path, filename:dirname(OFile)}, OFile}
         end,
     {ok, Code} = file:read_file(File),

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -278,7 +278,8 @@ format(Node, EmptyLines, Options) ->
     E = maps:get(encoding, Options, utf8),
     OptList = [{empty_lines, sets:from_list(EmptyLines)} | maps:to_list(Options)],
     PreFormatted = prettypr:format(layout(Node, OptList), W, L),
-    binary_to_list(unicode:characters_to_binary(PreFormatted, E)).
+    binary_to_list(
+        unicode:characters_to_binary(PreFormatted, E)).
 
 %% =====================================================================
 %% @spec best(Tree::syntaxTree()) -> empty | prettypr:document()
@@ -362,8 +363,11 @@ do_lay(Node, Ctxt) ->
     case erl_syntax:has_comments(Node) of
         true ->
             D1 = lay_no_comments(Node, Ctxt),
-            D2 = lay_postcomments(erl_syntax:get_postcomments(Node), D1),
-            lay_precomments(erl_syntax:get_precomments(Node), D2);
+            D2 =
+                lay_postcomments(
+                    erl_syntax:get_postcomments(Node), D1),
+            lay_precomments(
+                erl_syntax:get_precomments(Node), D2);
         false -> lay_no_comments(Node, Ctxt)
     end.
 
@@ -381,7 +385,9 @@ lay_postcomments(Cs, D) -> beside(D, floating(break(stack_comments(Cs, true)), 1
 %% and stack the listed comments above each other.
 
 stack_comments([C | Cs], Pad) ->
-    D = stack_comment_lines(erl_syntax:comment_text(C)),
+    D =
+        stack_comment_lines(
+            erl_syntax:comment_text(C)),
     D1 =
         case Pad of
             true ->
@@ -417,16 +423,25 @@ add_comment_prefix(S) -> [$% | S].
 lay_no_comments(Node, Ctxt) ->
     case erl_syntax:type(Node) of
         %% We list literals and other common cases first.
-        variable -> text(erl_syntax:variable_literal(Node));
-        atom -> text(erl_syntax:atom_literal(Node, Ctxt#ctxt.encoding));
+        variable ->
+            text(
+                erl_syntax:variable_literal(Node));
+        atom ->
+            text(
+                erl_syntax:atom_literal(Node, Ctxt#ctxt.encoding));
         integer -> text(tidy_integer(Node));
         float -> text(tidy_float(Node));
-        char -> text(erl_syntax:char_literal(Node, Ctxt#ctxt.encoding));
-        string -> lay_string(erl_syntax:string_literal(Node, Ctxt#ctxt.encoding), Ctxt);
+        char ->
+            text(
+                erl_syntax:char_literal(Node, Ctxt#ctxt.encoding));
+        string ->
+            lay_string(
+                erl_syntax:string_literal(Node, Ctxt#ctxt.encoding), Ctxt);
         nil -> text("[]");
         tuple ->
             Es =
-                seq(erl_syntax:tuple_elements(Node),
+                seq(
+                    erl_syntax:tuple_elements(Node),
                     lay_text_float(","),
                     reset_prec(Ctxt),
                     fun lay/2),
@@ -434,7 +449,9 @@ lay_no_comments(Node, Ctxt) ->
         list ->
             Ctxt1 = reset_prec(Ctxt),
             Node1 = erl_syntax:compact_list(Node),
-            D1 = sep(seq(erl_syntax:list_prefix(Node1), lay_text_float(","), Ctxt1, fun lay/2)),
+            D1 =
+                sep(seq(
+                        erl_syntax:list_prefix(Node1), lay_text_float(","), Ctxt1, fun lay/2)),
             D =
                 case erl_syntax:list_suffix(Node1) of
                     none -> beside(D1, lay_text_float("]"));
@@ -444,17 +461,25 @@ lay_no_comments(Node, Ctxt) ->
                                       beside(lay(S, Ctxt1), lay_text_float("]"))))
                 end,
             beside(lay_text_float("["), D);
-        operator -> lay_text_float(erl_syntax:operator_literal(Node));
+        operator ->
+            lay_text_float(
+                erl_syntax:operator_literal(Node));
         infix_expr ->
             Operator = erl_syntax:infix_expr_operator(Node),
             {PrecL, Prec, PrecR} =
                 case erl_syntax:type(Operator) of
-                    operator -> inop_prec(erl_syntax:operator_name(Operator));
+                    operator ->
+                        inop_prec(
+                            erl_syntax:operator_name(Operator));
                     _ -> {0, 0, 0}
                 end,
-            D1 = lay(erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
+            D1 =
+                lay(
+                    erl_syntax:infix_expr_left(Node), set_prec(Ctxt, PrecL)),
             D2 = lay(Operator, reset_prec(Ctxt)),
-            D3 = lay(erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
+            D3 =
+                lay(
+                    erl_syntax:infix_expr_right(Node), set_prec(Ctxt, PrecR)),
             D4 = par([D1, D2, D3], Ctxt#ctxt.break_indent),
             maybe_parentheses(D4, Prec, Ctxt);
         prefix_expr ->
@@ -467,7 +492,9 @@ lay_no_comments(Node, Ctxt) ->
                     _ -> {{0, 0}, any}
                 end,
             D1 = lay(Operator, reset_prec(Ctxt)),
-            D2 = lay(erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
+            D2 =
+                lay(
+                    erl_syntax:prefix_expr_argument(Node), set_prec(Ctxt, PrecR)),
             D3 =
                 case Name of
                     '+' -> beside(D1, D2);
@@ -477,9 +504,12 @@ lay_no_comments(Node, Ctxt) ->
             maybe_parentheses(D3, Prec, Ctxt);
         application ->
             {PrecL, Prec} = func_prec(),
-            D = lay(erl_syntax:application_operator(Node), set_prec(Ctxt, PrecL)),
+            D =
+                lay(
+                    erl_syntax:application_operator(Node), set_prec(Ctxt, PrecL)),
             As =
-                seq(erl_syntax:application_arguments(Node),
+                seq(
+                    erl_syntax:application_arguments(Node),
                     floating(text(",")),
                     reset_prec(Ctxt),
                     fun lay/2),
@@ -487,21 +517,29 @@ lay_no_comments(Node, Ctxt) ->
             maybe_parentheses(D1, Prec, Ctxt);
         match_expr ->
             {PrecL, Prec, PrecR} = inop_prec('='),
-            D1 = lay(erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
-            D2 = lay(erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:match_expr_pattern(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                lay(
+                    erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
             D3 = follow(beside(D1, lay_text_float(" =")), D2, Ctxt#ctxt.break_indent),
             maybe_parentheses(D3, Prec, Ctxt);
         underscore -> text("_");
         clause ->
             %% The style used for a clause depends on its context
             Ctxt1 = (reset_prec(Ctxt))#ctxt{clause = undefined},
-            D1 = par(seq(erl_syntax:clause_patterns(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D1 =
+                par(seq(
+                        erl_syntax:clause_patterns(Node), lay_text_float(","), Ctxt1, fun lay/2)),
             D2 =
                 case erl_syntax:clause_guard(Node) of
                     none -> none;
                     G -> lay(G, Ctxt1)
                 end,
-            D3 = lay_clause_expressions(erl_syntax:clause_body(Node), Ctxt1),
+            D3 =
+                lay_clause_expressions(
+                    erl_syntax:clause_body(Node), Ctxt1),
             case Ctxt#ctxt.clause of
                 fun_expr -> make_fun_clause(D1, D2, D3, Ctxt);
                 {function, N} -> make_fun_clause(N, D1, D2, D3, Ctxt);
@@ -518,42 +556,66 @@ lay_no_comments(Node, Ctxt) ->
             %% Comments on the name itself will be repeated for each
             %% clause, but that seems to be the best way to handle it.
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:function_name(Node), Ctxt1),
-            D2 = lay_clauses(erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:function_name(Node), Ctxt1),
+            D2 =
+                lay_clauses(
+                    erl_syntax:function_clauses(Node), {function, D1}, Ctxt1),
             beside(D2, lay_text_float("."));
         case_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:case_expr_argument(Node), Ctxt1),
-            D2 = lay_clauses(erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:case_expr_argument(Node), Ctxt1),
+            D2 =
+                lay_clauses(
+                    erl_syntax:case_expr_clauses(Node), case_expr, Ctxt1),
             sep([par([follow(text("case"), D1, Ctxt1#ctxt.break_indent), text("of")],
                      Ctxt1#ctxt.break_indent),
                  nest(Ctxt1#ctxt.break_indent, D2),
                  text("end")]);
         if_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D = lay_clauses(erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
+            D =
+                lay_clauses(
+                    erl_syntax:if_expr_clauses(Node), if_expr, Ctxt1),
             sep([follow(text("if"), D, Ctxt1#ctxt.break_indent), text("end")]);
         fun_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            Clauses = lay_clauses(erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
+            Clauses =
+                lay_clauses(
+                    erl_syntax:fun_expr_clauses(Node), fun_expr, Ctxt1),
             lay_fun_sep(Clauses, Ctxt1);
         named_fun_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:named_fun_expr_name(Node), Ctxt1),
-            Clauses = lay_clauses(erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:named_fun_expr_name(Node), Ctxt1),
+            Clauses =
+                lay_clauses(
+                    erl_syntax:named_fun_expr_clauses(Node), {function, D1}, Ctxt1),
             lay_fun_sep(Clauses, Ctxt1);
         module_qualifier ->
             {PrecL, _Prec, PrecR} = inop_prec(':'),
-            D1 = lay(erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
-            D2 = lay(erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:module_qualifier_argument(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                lay(
+                    erl_syntax:module_qualifier_body(Node), set_prec(Ctxt, PrecR)),
             beside(D1, beside(text(":"), D2));
         %%
         %% The rest is in alphabetical order (except map and types)
         %%
         arity_qualifier ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:arity_qualifier_body(Node), Ctxt1),
-            D2 = lay(erl_syntax:arity_qualifier_argument(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:arity_qualifier_body(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:arity_qualifier_argument(Node), Ctxt1),
             beside(D1, beside(text("/"), D2));
         attribute ->
             %% The attribute name and arguments are formatted similar to
@@ -574,7 +636,9 @@ lay_no_comments(Node, Ctxt) ->
                         [FuncName, FuncTypes] = erl_syntax:tuple_elements(SpecTuple),
                         Name = get_func_node(FuncName),
                         Types = dodge_macros(FuncTypes),
-                        D1 = lay_clauses(erl_syntax:concrete(Types), spec, Ctxt1),
+                        D1 =
+                            lay_clauses(
+                                erl_syntax:concrete(Types), spec, Ctxt1),
                         beside(follow(lay(N, Ctxt1), lay(Name, Ctxt1), Ctxt1#ctxt.break_indent),
                                D1);
                     type ->
@@ -585,7 +649,9 @@ lay_no_comments(Node, Ctxt) ->
                         As0 = dodge_macros(Elements),
                         As = erl_syntax:concrete(As0),
                         D1 = lay_type_application(TypeName, As, Ctxt1),
-                        D2 = lay(erl_syntax:concrete(Type), Ctxt1),
+                        D2 =
+                            lay(
+                                erl_syntax:concrete(Type), Ctxt1),
                         beside(follow(lay(N, Ctxt1),
                                       beside(D1, lay_text_float(" :: ")),
                                       Ctxt1#ctxt.break_indent),
@@ -604,11 +670,15 @@ lay_no_comments(Node, Ctxt) ->
             beside(lay_text_float("-"), beside(D, lay_text_float(".")));
         binary ->
             Ctxt1 = reset_prec(Ctxt),
-            Es = seq(erl_syntax:binary_fields(Node), lay_text_float(","), Ctxt1, fun lay/2),
+            Es =
+                seq(
+                    erl_syntax:binary_fields(Node), lay_text_float(","), Ctxt1, fun lay/2),
             beside(lay_text_float("<<"), beside(par(Es), lay_text_float(">>")));
         binary_field ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 = lay(erl_syntax:binary_field_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:binary_field_body(Node), Ctxt1),
             D2 =
                 case erl_syntax:binary_field_types(Node) of
                     [] -> empty();
@@ -617,17 +687,25 @@ lay_no_comments(Node, Ctxt) ->
             beside(D1, D2);
         block_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            Es = seq(erl_syntax:block_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2),
+            Es =
+                seq(
+                    erl_syntax:block_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2),
             sep([text("begin"), nest(Ctxt1#ctxt.break_indent, sep(Es)), text("end")]);
         catch_expr ->
             {Prec, PrecR} = preop_prec('catch'),
-            D = lay(erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
+            D =
+                lay(
+                    erl_syntax:catch_expr_body(Node), set_prec(Ctxt, PrecR)),
             D1 = follow(text("catch"), D, Ctxt#ctxt.break_indent),
             maybe_parentheses(D1, Prec, Ctxt);
         class_qualifier ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 = lay(erl_syntax:class_qualifier_argument(Node), Ctxt1),
-            D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:class_qualifier_argument(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:class_qualifier_body(Node), Ctxt1),
             Stacktrace = erl_syntax:class_qualifier_stacktrace(Node),
             case erl_syntax:variable_name(Stacktrace) of
                 '_' -> beside(D1, beside(text(":"), D2));
@@ -636,21 +714,25 @@ lay_no_comments(Node, Ctxt) ->
                     beside(D1, beside(beside(text(":"), D2), beside(text(":"), D3)))
             end;
         comment ->
-            D = stack_comment_lines(erl_syntax:comment_text(Node)),
+            D =
+                stack_comment_lines(
+                    erl_syntax:comment_text(Node)),
             %% Default padding for standalone comments is empty.
             case erl_syntax:comment_padding(Node) of
                 none -> floating(break(D));
                 P -> floating(break(beside(text(spaces(P)), D)))
             end;
         conjunction ->
-            par(seq(erl_syntax:conjunction_body(Node),
+            par(seq(
+                    erl_syntax:conjunction_body(Node),
                     lay_text_float(","),
                     reset_prec(Ctxt),
                     fun lay/2));
         disjunction ->
             %% For clarity, we don't paragraph-format
             %% disjunctions; only conjunctions (see above).
-            sep(seq(erl_syntax:disjunction_body(Node),
+            sep(seq(
+                    erl_syntax:disjunction_body(Node),
                     lay_text_float(";"),
                     reset_prec(Ctxt),
                     fun lay/2));
@@ -659,31 +741,51 @@ lay_no_comments(Node, Ctxt) ->
             beside(text("** "), beside(lay_error_info(E, reset_prec(Ctxt)), text(" **")));
         eof_marker -> empty();
         form_list ->
-            Es = seq(erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
+            Es =
+                seq(
+                    erl_syntax:form_list_elements(Node), none, reset_prec(Ctxt), fun lay/2),
             vertical_sep(text(""), Es);
         generator ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:generator_pattern(Node), Ctxt1),
-            D2 = lay(erl_syntax:generator_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:generator_pattern(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:generator_body(Node), Ctxt1),
             par([D1, beside(text("<- "), D2)], Ctxt1#ctxt.break_indent);
         binary_generator ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
-            D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:binary_generator_pattern(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:binary_generator_body(Node), Ctxt1),
             par([D1, beside(text("<= "), D2)], Ctxt1#ctxt.break_indent);
         implicit_fun ->
-            D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
+            D =
+                lay(
+                    erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
             beside(lay_text_float("fun "), D);
         list_comp ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:list_comp_template(Node), Ctxt1),
-            D2 = par(seq(erl_syntax:list_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D1 =
+                lay(
+                    erl_syntax:list_comp_template(Node), Ctxt1),
+            D2 =
+                par(seq(
+                        erl_syntax:list_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
             beside(lay_text_float("["),
                    par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float("]")))]));
         binary_comp ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:binary_comp_template(Node), Ctxt1),
-            D2 = par(seq(erl_syntax:binary_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D1 =
+                lay(
+                    erl_syntax:binary_comp_template(Node), Ctxt1),
+            D2 =
+                par(seq(
+                        erl_syntax:binary_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
             beside(lay_text_float("<< "),
                    par([D1, beside(lay_text_float(" || "), beside(D2, lay_text_float(" >>")))]));
         macro ->
@@ -704,11 +806,15 @@ lay_no_comments(Node, Ctxt) ->
                               0,
                               Ctxt);    % must be conservative!
         parentheses ->
-            D = lay(erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
+            D =
+                lay(
+                    erl_syntax:parentheses_body(Node), reset_prec(Ctxt)),
             lay_parentheses(D, Ctxt);
         receive_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay_clauses(erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
+            D1 =
+                lay_clauses(
+                    erl_syntax:receive_expr_clauses(Node), receive_expr, Ctxt1),
             D2 =
                 case erl_syntax:receive_expr_timeout(Node) of
                     none -> D1;
@@ -724,18 +830,24 @@ lay_no_comments(Node, Ctxt) ->
             sep([text("receive"), nest(Ctxt1#ctxt.break_indent, D2), text("end")]);
         record_access ->
             {PrecL, Prec, PrecR} = inop_prec('#'),
-            D1 = lay(erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
+            D1 =
+                lay(
+                    erl_syntax:record_access_argument(Node), set_prec(Ctxt, PrecL)),
             D2 =
                 beside(lay_text_float("."),
-                       lay(erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
+                       lay(
+                           erl_syntax:record_access_field(Node), set_prec(Ctxt, PrecR))),
             T = erl_syntax:record_access_type(Node),
             D3 = beside(beside(lay_text_float("#"), lay(T, reset_prec(Ctxt))), D2),
             maybe_parentheses(beside(D1, D3), Prec, Ctxt);
         record_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:record_expr_type(Node), Ctxt1),
             D2 =
-                par(seq(erl_syntax:record_expr_fields(Node),
+                par(seq(
+                        erl_syntax:record_expr_fields(Node),
                         lay_text_float(","),
                         Ctxt1,
                         fun lay/2)),
@@ -746,20 +858,28 @@ lay_no_comments(Node, Ctxt) ->
             lay_expr_argument(Arg, D3, Ctxt);
         record_field ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:record_field_name(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:record_field_name(Node), Ctxt1),
             case erl_syntax:record_field_value(Node) of
                 none -> D1;
                 V -> par([D1, lay_text_float("="), lay(V, Ctxt1)], Ctxt1#ctxt.break_indent)
             end;
         record_index_expr ->
             {Prec, PrecR} = preop_prec('#'),
-            D1 = lay(erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
-            D2 = lay(erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:record_index_expr_type(Node), reset_prec(Ctxt)),
+            D2 =
+                lay(
+                    erl_syntax:record_index_expr_field(Node), set_prec(Ctxt, PrecR)),
             D3 = beside(beside(lay_text_float("#"), D1), beside(lay_text_float("."), D2)),
             maybe_parentheses(D3, Prec, Ctxt);
         map_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = par(seq(erl_syntax:map_expr_fields(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D1 =
+                par(seq(
+                        erl_syntax:map_expr_fields(Node), lay_text_float(","), Ctxt1, fun lay/2)),
             D2 = beside(text("#{"), beside(D1, lay_text_float("}"))),
             Arg = erl_syntax:map_expr_argument(Node),
             lay_expr_argument(Arg, D2, Ctxt);
@@ -773,20 +893,32 @@ lay_no_comments(Node, Ctxt) ->
             lay_type_exact(Name, Value, Ctxt);
         size_qualifier ->
             Ctxt1 = set_prec(Ctxt, max_prec()),
-            D1 = lay(erl_syntax:size_qualifier_body(Node), Ctxt1),
-            D2 = lay(erl_syntax:size_qualifier_argument(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:size_qualifier_body(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:size_qualifier_argument(Node), Ctxt1),
             beside(D1, beside(text(":"), D2));
-        text -> text(erl_syntax:text_string(Node));
+        text ->
+            text(
+                erl_syntax:text_string(Node));
         typed_record_field ->
             {_, Prec, _} = type_inop_prec('::'),
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:typed_record_field_body(Node), Ctxt1),
-            D2 = lay(erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
+            D1 =
+                lay(
+                    erl_syntax:typed_record_field_body(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:typed_record_field_type(Node), set_prec(Ctxt, Prec)),
             D3 = par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent),
             maybe_parentheses(D3, Prec, Ctxt);
         try_expr ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = sep(seq(erl_syntax:try_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            D1 =
+                sep(seq(
+                        erl_syntax:try_expr_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
             Es0 = [text("end")],
             Es1 =
                 case erl_syntax:try_expr_after(Node) of
@@ -818,8 +950,12 @@ lay_no_comments(Node, Ctxt) ->
         %%
         annotated_type ->
             {_, Prec, _} = type_inop_prec('::'),
-            D1 = lay(erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
-            D2 = lay(erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
+            D1 =
+                lay(
+                    erl_syntax:annotated_type_name(Node), reset_prec(Ctxt)),
+            D2 =
+                lay(
+                    erl_syntax:annotated_type_body(Node), set_prec(Ctxt, Prec)),
             D3 = lay_follow_beside_text_float(D1, D2, Ctxt),
             maybe_parentheses(D3, Prec, Ctxt);
         type_application ->
@@ -854,9 +990,13 @@ lay_no_comments(Node, Ctxt) ->
         fun_type -> text("fun()");
         constrained_function_type ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:constrained_function_type_body(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:constrained_function_type_body(Node), Ctxt1),
             Ctxt2 = Ctxt1#ctxt{clause = undefined},
-            D2 = lay(erl_syntax:constrained_function_type_argument(Node), Ctxt2),
+            D2 =
+                lay(
+                    erl_syntax:constrained_function_type_argument(Node), Ctxt2),
             beside(D1, beside(lay_text_float(" when "), D2));
         function_type ->
             {Before, After} =
@@ -872,7 +1012,9 @@ lay_no_comments(Node, Ctxt) ->
                         As = seq(Arguments, lay_text_float(","), Ctxt1, fun lay/2),
                         beside(text("("), beside(par(As), lay_text_float(")")))
                 end,
-            D2 = lay(erl_syntax:function_type_return(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:function_type_return(Node), Ctxt1),
             beside(lay_text_float(Before),
                    beside(D1, beside(lay_text_float(" -> "), beside(D2, lay_text_float(After)))));
         constraint ->
@@ -908,15 +1050,23 @@ lay_no_comments(Node, Ctxt) ->
             lay_type_exact(Name, Value, Ctxt);
         integer_range_type ->
             {PrecL, Prec, PrecR} = type_inop_prec('..'),
-            D1 = lay(erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
-            D2 = lay(erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
+            D1 =
+                lay(
+                    erl_syntax:integer_range_type_low(Node), set_prec(Ctxt, PrecL)),
+            D2 =
+                lay(
+                    erl_syntax:integer_range_type_high(Node), set_prec(Ctxt, PrecR)),
             D3 = beside(D1, beside(text(".."), D2)),
             maybe_parentheses(D3, Prec, Ctxt);
         record_type ->
             {Prec, _PrecR} = type_preop_prec('#'),
-            D1 = beside(text("#"), lay(erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
+            D1 =
+                beside(text("#"),
+                       lay(
+                           erl_syntax:record_type_name(Node), reset_prec(Ctxt))),
             Es =
-                seq(erl_syntax:record_type_fields(Node),
+                seq(
+                    erl_syntax:record_type_fields(Node),
                     lay_text_float(","),
                     reset_prec(Ctxt),
                     fun lay/2),
@@ -924,8 +1074,12 @@ lay_no_comments(Node, Ctxt) ->
             maybe_parentheses(D2, Prec, Ctxt);
         record_type_field ->
             Ctxt1 = reset_prec(Ctxt),
-            D1 = lay(erl_syntax:record_type_field_name(Node), Ctxt1),
-            D2 = lay(erl_syntax:record_type_field_type(Node), Ctxt1),
+            D1 =
+                lay(
+                    erl_syntax:record_type_field_name(Node), Ctxt1),
+            D2 =
+                lay(
+                    erl_syntax:record_type_field_type(Node), Ctxt1),
             par([D1, lay_text_float("::"), D2], Ctxt1#ctxt.break_indent);
         tuple_type ->
             case erl_syntax:tuple_type_elements(Node) of
@@ -937,15 +1091,17 @@ lay_no_comments(Node, Ctxt) ->
         type_union ->
             {_, Prec, PrecR} = type_inop_prec('|'),
             Es =
-                sep(seq(erl_syntax:type_union_types(Node),
+                sep(seq(
+                        erl_syntax:type_union_types(Node),
                         lay_text_float(" |"),
                         set_prec(Ctxt, PrecR),
                         fun lay/2)),
             maybe_parentheses(Es, Prec, Ctxt);
         user_type_application ->
-            lay_type_application(erl_syntax:user_type_application_name(Node),
-                                 erl_syntax:user_type_application_arguments(Node),
-                                 Ctxt)
+            lay_type_application(
+                erl_syntax:user_type_application_name(Node),
+                erl_syntax:user_type_application_arguments(Node),
+                Ctxt)
     end.
 
 attribute_type(Node) ->
@@ -978,7 +1134,8 @@ get_func_node(Node) ->
 unfold_function_names(Ns) ->
     F =
         fun ({Atom, Arity}) ->
-                erl_syntax:arity_qualifier(erl_syntax:atom(Atom), erl_syntax:integer(Arity))
+                erl_syntax:arity_qualifier(
+                    erl_syntax:atom(Atom), erl_syntax:integer(Arity))
         end,
     erl_syntax:list([F(N) || N <- Ns]).
 
@@ -1125,14 +1282,19 @@ lay_error_info({L, M, T} = T0, Ctxt) when is_integer(L), is_atom(M) ->
     case catch apply(M, format_error, [T]) of
         S when is_list(S) ->
             case L > 0 of
-                true -> beside(text(io_lib:format("~w: ", [L])), text(S));
+                true ->
+                    beside(text(
+                               io_lib:format("~w: ", [L])),
+                           text(S));
                 _ -> text(S)
             end;
         _ -> lay_concrete(T0, Ctxt)
     end;
 lay_error_info(T, Ctxt) -> lay_concrete(T, Ctxt).
 
-lay_concrete(T, Ctxt) -> lay(erl_syntax:abstract(T), Ctxt).
+lay_concrete(T, Ctxt) ->
+    lay(
+        erl_syntax:abstract(T), Ctxt).
 
 lay_type_assoc(Name, Value, Ctxt) -> lay_type_par_text(Name, Value, "=>", Ctxt).
 

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -978,7 +978,8 @@ get_func_node(Node) ->
 unfold_function_names(Ns) ->
     F =
         fun({Atom, Arity}) ->
-           erl_syntax:arity_qualifier(erl_syntax:atom(Atom), erl_syntax:integer(Arity))
+           erl_syntax:arity_qualifier(
+               erl_syntax:atom(Atom), erl_syntax:integer(Arity))
         end,
     erl_syntax:list([F(N) || N <- Ns]).
 

--- a/src/formatters/sr_formatter.erl
+++ b/src/formatters/sr_formatter.erl
@@ -69,7 +69,9 @@ parse_opt(K, V, Opts) ->
     [{K, V} | Opts].
 
 copy_file(File, OutputDir) ->
-    OutFile = filename:join(filename:absname(OutputDir), File),
+    OutFile =
+        filename:join(
+            filename:absname(OutputDir), File),
     ok = filelib:ensure_dir(OutFile),
     {ok, _} = file:copy(File, OutFile),
     OutFile.

--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -24,9 +24,7 @@ format(File, Formatter, Opts) ->
             _ ->
                 changed
         end,
-    case maybe_save_file(
-             maps:get(output_dir, Opts), File, Formatted)
-        of
+    case maybe_save_file(maps:get(output_dir, Opts), File, Formatted) of
         none ->
             Result;
         NewFile ->

--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -24,7 +24,9 @@ format(File, Formatter, Opts) ->
             _ ->
                 changed
         end,
-    case maybe_save_file(maps:get(output_dir, Opts), File, Formatted) of
+    case maybe_save_file(
+             maps:get(output_dir, Opts), File, Formatted)
+        of
         none ->
             Result;
         NewFile ->
@@ -70,7 +72,9 @@ get_comments(File) ->
     erl_comment_scan:file(File).
 
 format(File, AST, Formatter, Comments, Opts) ->
-    WithComments = erl_recomment:recomment_forms(erl_syntax:form_list(AST), Comments),
+    WithComments =
+        erl_recomment:recomment_forms(
+            erl_syntax:form_list(AST), Comments),
     Formatted = Formatter:format(WithComments, empty_lines(File), Opts),
     insert_last_line(iolist_to_binary(Formatted)).
 
@@ -106,7 +110,9 @@ maybe_save_file(current, File, Formatted) ->
     ok = file:write_file(File, Formatted),
     File;
 maybe_save_file(OutputDir, File, Formatted) ->
-    OutFile = filename:join(filename:absname(OutputDir), File),
+    OutFile =
+        filename:join(
+            filename:absname(OutputDir), File),
     ok = filelib:ensure_dir(OutFile),
     ok = file:write_file(OutFile, Formatted),
     OutFile.

--- a/src/rebar3_formatter.erl
+++ b/src/rebar3_formatter.erl
@@ -44,7 +44,9 @@ format_file(File, #{opts := Opts, module := Module, state := State} = Formatter)
 %%      are not formatting to it
 -spec ignore(file:filename_all(), t()) -> ok.
 ignore(File, #{opts := #{output_dir := OutputDir}}) when not is_atom(OutputDir) ->
-    OutFile = filename:join(filename:absname(OutputDir), File),
+    OutFile =
+        filename:join(
+            filename:absname(OutputDir), File),
     ok = filelib:ensure_dir(OutFile),
     {ok, _} = file:copy(File, OutFile),
     ok;

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -36,8 +36,8 @@ action(_Config) ->
     {ok, _} = rebar3_format_prv:do(Args2),
 
     erlfmt:validator(fun (_, {path, Out}, _) ->
-                             file:write_file(filename:join(Out, "brackets.erl"),
-                                             "something different"),
+                             file:write_file(
+                                 filename:join(Out, "brackets.erl"), "something different"),
                              {ok, []}
                      end),
     {error, _} = rebar3_format_prv:do(Args1).
@@ -126,8 +126,13 @@ init() ->
     init(#{}).
 
 init(Opts) ->
-    ok = file:set_cwd(filename:join(code:priv_dir(rebar3_format), "../test_app")),
-    {ok, State1} = rebar3_format:init(rebar_state:new()),
+    ok =
+        file:set_cwd(
+            filename:join(
+                code:priv_dir(rebar3_format), "../test_app")),
+    {ok, State1} =
+        rebar3_format:init(
+            rebar_state:new()),
     Files = {files, ["src/brackets.erl"]},
     Formatter = {formatter, erlfmt_formatter},
     Out = {options, Opts},

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -36,7 +36,8 @@ action(_Config) ->
     {ok, _} = rebar3_format_prv:do(Args2),
 
     erlfmt:validator(fun(_, {path, Out}, _) ->
-                        file:write_file(filename:join(Out, "brackets.erl"), "something different"),
+                        file:write_file(
+                            filename:join(Out, "brackets.erl"), "something different"),
                         {ok, []}
                      end),
     {error, _} = rebar3_format_prv:do(Args1).

--- a/test/sr_formatter_SUITE.erl
+++ b/test/sr_formatter_SUITE.erl
@@ -60,8 +60,13 @@ init() ->
     init(#{}).
 
 init(Options) ->
-    ok = file:set_cwd(filename:join(code:priv_dir(rebar3_format), "../test_app")),
-    {ok, State1} = rebar3_format:init(rebar_state:new()),
+    ok =
+        file:set_cwd(
+            filename:join(
+                code:priv_dir(rebar3_format), "../test_app")),
+    {ok, State1} =
+        rebar3_format:init(
+            rebar_state:new()),
     Files = {files, ["src/brackets.erl"]},
     Formatter = {formatter, sr_formatter},
     Opts = {options, Options},

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -7,10 +7,14 @@ all() ->
 
 test_app(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
-    {ok, State1} = rebar3_format:init(rebar_state:new()),
+    {ok, State1} =
+        rebar3_format:init(
+            rebar_state:new()),
     Files = {files, ["src/*.erl", "include/*.hrl"]},
     IgnoredFiles =
-        case string:to_integer(erlang:system_info(otp_release)) of
+        case string:to_integer(
+                 erlang:system_info(otp_release))
+            of
             {N, []} when N >= 23 ->
                 {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
             _ ->
@@ -26,12 +30,12 @@ test_app(_Config) ->
     ok = git_diff().
 
 verify(State) ->
-    rebar3_format_prv:do(rebar_state:command_parsed_args(State,
-                                                         {[{verify, true}], something})).
+    rebar3_format_prv:do(
+        rebar_state:command_parsed_args(State, {[{verify, true}], something})).
 
 format(State) ->
-    rebar3_format_prv:do(rebar_state:command_parsed_args(State,
-                                                         {[{output, "formatted"}], something})).
+    rebar3_format_prv:do(
+        rebar_state:command_parsed_args(State, {[{output, "formatted"}], something})).
 
 git_diff() ->
     case os:cmd("git --no-pager diff --no-index -- after formatted") of

--- a/test_app/after/src/function_composition.erl
+++ b/test_app/after/src/function_composition.erl
@@ -1,0 +1,27 @@
+-module(function_composition).
+
+-export([local_calls/3, external_calls/0]).
+
+-type t() :: only:function(application:is(affected(by:this(change)))) | not_types.
+
+local_calls(should, be, unaffected) ->
+    g(f(b, h(a), w(x(y)))).
+
+external_calls() ->
+    should:be(
+        indented:every(
+            singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+        local_calls(?MACROS(should), be, unaffected)),
+    the_idea_is_to_force:long_module_and_function_names(
+        to_be_put:in_the_next_row([{so, that},
+                                   "their",
+                                   <<"parameters">>,
+                                   can:be(),
+                                   read,
+                                   more,
+                                   easily])),
+    this_one(
+        will:be(more(
+                    complex:since(
+                        it:combines(), local:and_remote(calls))),
+                hopefully:it(is(a, rare, thing)))).

--- a/test_app/after/src/function_composition.erl
+++ b/test_app/after/src/function_composition.erl
@@ -20,8 +20,6 @@ external_calls() ->
                                    read,
                                    more,
                                    easily])),
-    this_one(
-        will:be(more(
-                    complex:since(
-                        it:combines(), local:and_remote(calls))),
-                hopefully:it(is(a, rare, thing)))).
+    this_one(will:be(more(complex:since(
+                              it:combines(), local:and_remote(calls))),
+                     hopefully:it(is(a, rare, thing)))).

--- a/test_app/after/src/indent_1.erl
+++ b/test_app/after/src/indent_1.erl
@@ -6,11 +6,13 @@
 
 -record(record,
         {fields =
-          should:be(indented_using:break_indent(1)),
+          should:be(
+           indented_using:break_indent(1)),
          including ::
           those:that_use_types(with_very_long_names),
          what_about =
-          fields_with:very_long_values(and_very:long_type_names())
+          fields_with:very_long_values(
+           and_very:long_type_names())
           ::
           they:also(should:be(indented_using:break_indent(1)))}).
 
@@ -24,18 +26,22 @@ prefix_expr() ->
 
 match_expr() ->
  ThisVeryVeryVeryLongMatchExpression =
-  should:be(indented_using:break_indent(1)).
+  should:be(
+   indented_using:break_indent(1)).
 
 case_expr() ->
  case expressions:that(are_too_long_for_a_line,
-                       should:be(indented_using:break_indent(1)),
+                       should:be(
+                        indented_using:break_indent(1)),
                        but,
                        the,
                        "of",
-                       should:be(indented_using:break_indent(1)))
+                       should:be(
+                        indented_using:break_indent(1)))
   of
   clauses ->
-   should:be(indented_using:break_indent(1))
+   should:be(
+    indented_using:break_indent(1))
  end.
 
 if_expr() ->
@@ -56,62 +62,76 @@ a_function_with_a_very_long_name() ->
  {specs,
   " and ",
   types,
-  should:be(indented_using:break_indent(1))}.
+  should:be(
+   indented_using:break_indent(1))}.
 
 block_expr() ->
  begin
   block:expressions(),
-  should:be(indented_using:break_indent(1))
+  should:be(
+   indented_using:break_indent(1))
  end.
 
 catch_expr() ->
- catch
-  exp:ressions(should:be(indented_using:break_indent(1))).
+ catch exp:ressions(
+        should:be(
+         indented_using:break_indent(1))).
 
 list_generator() ->
  [generators
   || _In
-      <- list:comprehensions(should:be(indented_using:break_indent(1))),
+      <- list:comprehensions(
+          should:be(
+           indented_using:break_indent(1))),
      _Which
-      <- is:something(that:looks(quite:awful({in,
-                                              my,
-                                              opinion})))].
+      <- is:something(
+          that:looks(
+           quite:awful({in, my, opinion})))].
 
 binary_generator() ->
  << <<"generators">>
     || <<_In>>
-        <= list:comprehensions(should:be(indented_using:break_indent(1))),
+        <= list:comprehensions(
+            should:be(
+             indented_using:break_indent(1))),
        <<_Which>>
-        <= is:something(that:looks(quite:awful({in,
-                                                my,
-                                                opinion}))) >>.
+        <= is:something(
+            that:looks(
+             quite:awful({in, my, opinion}))) >>.
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
  receive
   clauses ->
-   should:be(indented_using:break_indent(1))
+   should:be(
+    indented_using:break_indent(1))
   after ExpressionsThatAreReallyTooLongForALine ->
-         should:be(indented_using:break_indent(1))
+         should:be(
+          indented_using:break_indent(1))
  end.
 
 try_expr() ->
  try expressions:that(are_too_long_for_a_line,
-                      should:be(indented_using:break_indent(1)),
+                      should:be(
+                       indented_using:break_indent(1)),
                       but,
                       the)
  of
   should -> not be:indented(at_all)
  catch
   Clauses:Should:Also ->
-   be:indented(using:break_indent(1))
+   be:indented(
+    using:break_indent(1))
  after
-  should:be(indented_using:break_indent(1))
+  should:be(
+   indented_using:break_indent(1))
  end.
 
 when_clause(A, B, C)
  when is_integer(A),
       B >= A andalso C rem 2 =:= 0 ->
- the:guard(should:be(indented_using:break_indent(1)));
+ the:guard(
+  should:be(
+   indented_using:break_indent(1)));
 when_clause(Along, Blonb, Clong)
  when is_integer(Along),
       Along >= Blong andalso

--- a/test_app/after/src/indent_8.erl
+++ b/test_app/after/src/indent_8.erl
@@ -5,11 +5,13 @@
 
 -record(record,
         {fields =
-                 should:be(indented_using:break_indent(8)),
+                 should:be(
+                         indented_using:break_indent(8)),
          including ::
                  those:that_use_types(with_very_long_names),
          what_about =
-                 fields_with:very_long_values(and_very:long_type_names())
+                 fields_with:very_long_values(
+                         and_very:long_type_names())
                  ::
                  they:also(should:be(indented_using:break_indent(8)))}).
 
@@ -24,19 +26,23 @@ prefix_expr() ->
 
 match_expr() ->
         ThisVeryVeryVeryLongMatchExpression =
-                should:be(indented_using:break_indent(8)).
+                should:be(
+                        indented_using:break_indent(8)).
 
 case_expr() ->
         case
                 expressions:that(are_too_long_for_a_line,
-                                 should:be(indented_using:break_indent(8)),
+                                 should:be(
+                                         indented_using:break_indent(8)),
                                  but,
                                  the,
                                  "of",
-                                 should:be(indented_using:break_indent(8)))
+                                 should:be(
+                                         indented_using:break_indent(8)))
                 of
                 clauses ->
-                        should:be(indented_using:break_indent(8))
+                        should:be(
+                                indented_using:break_indent(8))
         end.
 
 if_expr() ->
@@ -58,64 +64,82 @@ a_function_with_a_very_long_name() ->
         {specs,
          " and ",
          types,
-         should:be(indented_using:break_indent(8))}.
+         should:be(
+                 indented_using:break_indent(8))}.
 
 block_expr() ->
         begin
                 block:expressions(),
-                should:be(indented_using:break_indent(8))
+                should:be(
+                        indented_using:break_indent(8))
         end.
 
 catch_expr() ->
-        catch
-                exp:ressions(should:be(indented_using:break_indent(8))).
+        catch exp:ressions(
+                      should:be(
+                              indented_using:break_indent(8))).
 
 list_generator() ->
         [generators
          || _In
-                    <- list:comprehensions(should:be(indented_using:break_indent(8))),
+                    <- list:comprehensions(
+                               should:be(
+                                       indented_using:break_indent(8))),
             _Which
-                    <- is:something(that:looks(quite:awful({in,
-                                                            my,
-                                                            opinion})))].
+                    <- is:something(
+                               that:looks(
+                                       quite:awful({in,
+                                                    my,
+                                                    opinion})))].
 
 binary_generator() ->
         << <<"generators">>
            || <<_In>>
-                      <= list:comprehensions(should:be(indented_using:break_indent(8))),
+                      <= list:comprehensions(
+                                 should:be(
+                                         indented_using:break_indent(8))),
               <<_Which>>
-                      <= is:something(that:looks(quite:awful({in,
-                                                              my,
-                                                              opinion}))) >>.
+                      <= is:something(
+                                 that:looks(
+                                         quite:awful({in,
+                                                      my,
+                                                      opinion}))) >>.
 
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
         receive
                 clauses ->
-                        should:be(indented_using:break_indent(8))
+                        should:be(
+                                indented_using:break_indent(8))
                 after
                         ExpressionsThatAreReallyTooLongForALine ->
-                                should:be(indented_using:break_indent(8))
+                                should:be(
+                                        indented_using:break_indent(8))
         end.
 
 try_expr() ->
         try
                 expressions:that(are_too_long_for_a_line,
-                                 should:be(indented_using:break_indent(8)),
+                                 should:be(
+                                         indented_using:break_indent(8)),
                                  but,
                                  the)
         of
                 should -> not be:indented(at_all)
         catch
                 Clauses:Should:Also ->
-                        be:indented(using:break_indent(8))
+                        be:indented(
+                                using:break_indent(8))
         after
-                should:be(indented_using:break_indent(8))
+                should:be(
+                        indented_using:break_indent(8))
         end.
 
 when_clause(A, B, C)
         when is_integer(A),
              B >= A andalso C rem 2 =:= 0 ->
-        the:guard(should:be(indented_using:break_indent(8)));
+        the:guard(
+                should:be(
+                        indented_using:break_indent(8)));
 when_clause(Along, Blonb, Clong)
         when is_integer(Along),
              Along >= Blong andalso

--- a/test_app/after/src/indent_8.erl
+++ b/test_app/after/src/indent_8.erl
@@ -108,9 +108,11 @@ binary_generator() ->
 receive_after(ExpressionsThatAreReallyTooLongForALine) ->
         receive
                 clauses ->
-                        should:be(indented_using:break_indent(8))
+                        should:be(
+                                indented_using:break_indent(8))
                 after ExpressionsThatAreReallyTooLongForALine ->
-                        should:be(indented_using:break_indent(8))
+                        should:be(
+                                indented_using:break_indent(8))
         end.
 
 try_expr() ->

--- a/test_app/src/function_composition.erl
+++ b/test_app/src/function_composition.erl
@@ -1,0 +1,14 @@
+-module(function_composition).
+
+-export([local_calls/3, external_calls/0]).
+
+-type t() :: only:function(application:is(affected(by:this(change)))) | not_types.
+
+local_calls(should, be, unaffected) ->
+    g(f(b, h(a), w(x(y)))).
+
+external_calls() ->
+    should:be(indented:every(singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+        local_calls(?MACROS(should), be, unaffected)),
+    the_idea_is_to_force:long_module_and_function_names(to_be_put:in_the_next_row([{so, that}, "their", <<"parameters">>, can:be(), read, more, easily])),
+    this_one(will:be(more(complex:since(it:combines(), local:and_remote(calls))), hopefully:it(is(a, rare, thing)))).


### PR DESCRIPTION
This PR "fixes #140". It's very _hacky_ and it may lead to unexpected scenarios.
The idea behind it can be seen in `function_composition.erl`, but in a nutshell:

* The new behaviour only applies to function compositions; e.g. `f(g(h(…)))`
* The new behaviour only applies when function composition happens in the first argument of a function; e.g. not in this case: `f(a,g(b,h(c)))`.
* The new behaviour only applies when the functions that are composed are fully qualified (being that a _proxy_ for _has a long name_); e.g. in this case `d(f:f(g:g(h(…))))` the formatter will always put `g:g(…)` in the next row, but not `h(…)` nor `f:f(…)` will be moved to a new row.

This is far from ideal, but the way to properly indent things only when they're _in fact_ too long (i.e. using `sep/1` or `par/2`)… leads to undesired extra spaces after the opening brackets when the functions do fit in a single row (e.g. `f( g( h( …)))`).