### PR TITLE
[Fix #149] Add support for erlfmt 0.7.0

### DIFF
--- a/test/erlfmt.erl
+++ b/test/erlfmt.erl
@@ -1,33 +1,28 @@
 %%% @doc This module is only used for tests to simulate the actual erlfmt
 -module(erlfmt).
 
--export([format_file/2, format_file/3, validator/1]).
+-export([format_file/2, validator/1]).
 
 -type error_info() :: {file:name_all(), erl_anno:location(), module(), Reason :: any()}.
--type out() :: standard_out | {path, file:name_all()} | replace.
 -type pragma() :: require | insert | ignore.
 -type config() :: [{pragma, pragma()} | {width, pos_integer()}].
 
--spec validator(fun((file:name_all(), out()) ->
-                        {ok, [error_info()]} | {error, error_info()})) ->
+-spec validator(fun((file:name_all() | stdin, config()) ->
+                        {ok, [unicode:chardata()], [error_info()]} |
+                        {skip, string()} |
+                        {error, error_info()})) ->
                    ok.
 validator(Fun) ->
     application:set_env(rebar3_format, erlfmt_formatter_validator, Fun).
 
--spec format_file(file:name_all(), out()) -> {ok, [error_info()]} | {error, error_info()}.
-format_file(File, Opts) ->
+%% @doc First clause is 0.7.0, second one 0.6.0
+-spec format_file(file:name_all() | stdin, config()) ->
+                     {ok, [unicode:chardata()], [error_info()]} |
+                     {skip, string()} |
+                     {error, error_info()}.
+format_file(File, Options) ->
     Validator = validator(),
-    Validator(File, Opts).
-
--spec format_file(file:name_all(), out(), config()) ->
-                     {ok, [error_info()]} | {error, error_info()}.
-format_file(File, Out, Opts) ->
-    case validator() of
-        Validator when is_function(Validator, 3) ->
-            Validator(File, Out, Opts);
-        _ ->
-            erlang:error(undef)
-    end.
+    Validator(File, Options).
 
 validator() ->
     application:get_env(rebar3_format, erlfmt_formatter_validator, fun(_, _) -> ok end).

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -1,91 +1,70 @@
 -module(erlfmt_formatter_SUITE).
 
 -export([all/0]).
--export([action/1, output_dir/1, pragma/1, width/1, old_version/1]).
+-export([action/1, output_dir/1, pragma/1, width/1]).
 
 all() ->
-    [action, output_dir, pragma, width, old_version].
-
-old_version(_Config) ->
-    %% testing support for old version of erlfmt
-    erlfmt:validator(fun(File, {Pragma, Out}) ->
-                        "brackets.erl" = filename:basename(File),
-                        replace = Out,
-                        ignore = Pragma,
-                        {ok, []}
-                     end),
-    Args2 = rebar_state:command_parsed_args(init(), {[], something}),
-    {ok, _} = rebar3_format_prv:do(Args2).
+    [action, output_dir, pragma, width].
 
 action(_Config) ->
-    erlfmt:validator(fun(File, Out, _) ->
-                        "brackets.erl" = filename:basename(File),
-                        {path, "/tmp/src"} = Out,
-                        copy_file(File, "/tmp/src/brackets.erl"),
-                        {ok, []}
+    erlfmt:validator(fun(File, _) ->
+                        "minimal.erl" = filename:basename(File),
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args1 = rebar_state:command_parsed_args(init(), {[{verify, true}], something}),
     {ok, _} = rebar3_format_prv:do(Args1),
 
-    erlfmt:validator(fun(File, Out, _) ->
-                        "brackets.erl" = filename:basename(File),
-                        replace = Out,
-                        {ok, []}
+    erlfmt:validator(fun(File, _) ->
+                        "minimal.erl" = filename:basename(File),
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args2 = rebar_state:command_parsed_args(init(), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args2),
 
-    erlfmt:validator(fun(_, {path, Out}, _) ->
-                        file:write_file(
-                            filename:join(Out, "brackets.erl"), "something different"),
-                        {ok, []}
-                     end),
+    erlfmt:validator(fun(_, _) -> {ok, ["-module minimal.\n"], []} end),
     {error, _} = rebar3_format_prv:do(Args1).
 
 output_dir(_Config) ->
-    % When there is no expected output, erlfmt's out should be 'replace'
-    erlfmt:validator(fun(File, Out, _) ->
-                        "src/brackets.erl" = File,
-                        replace = Out,
-                        {ok, []}
+    erlfmt:validator(fun(File, _) ->
+                        "minimal.erl" = filename:basename(File),
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args1 = rebar_state:command_parsed_args(init(), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args1),
 
-    % When there is an expected output, erlfmt's out should be it
-    erlfmt:validator(fun(File, Out, _) ->
-                        "brackets.erl" = filename:basename(File),
-                        {path, "/tmp/src"} = Out,
-                        {ok, []}
+    erlfmt:validator(fun(File, _) ->
+                        "minimal.erl" = filename:basename(File),
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args2 = rebar_state:command_parsed_args(init(), {[{output, "/tmp/"}], something}),
-    {ok, _} = rebar3_format_prv:do(Args2).
+    {ok, _} = rebar3_format_prv:do(Args2),
+    {ok, <<"-module(minimal).\n">>} = file:read_file("/tmp/src/minimal.erl").
 
 pragma(_Config) ->
     % When there is no defined require_pragma nor insert_prgama, Pragma should be ignore
-    erlfmt:validator(fun(File, _, Opts) ->
-                        "src/brackets.erl" = File,
+    erlfmt:validator(fun(File, Opts) ->
+                        "src/minimal.erl" = File,
                         ignore = proplists:get_value(pragma, Opts),
-                        {ok, []}
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args1 = rebar_state:command_parsed_args(init(), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args1),
 
     % When require_pragma is true, erlfmt's pragma should be require
-    erlfmt:validator(fun(File, _, Opts) ->
-                        "brackets.erl" = filename:basename(File),
+    erlfmt:validator(fun(File, Opts) ->
+                        "minimal.erl" = filename:basename(File),
                         require = proplists:get_value(pragma, Opts),
-                        skip
+                        {skip, "-module(minimal).\n"}
                      end),
     Args2 = rebar_state:command_parsed_args(init(#{require_pragma => true}), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args2),
 
     % When require_pragma is false, erlfmt's pragma depends on insert_pragma
     % If insert_pragma is true, it should be insert
-    erlfmt:validator(fun(File, _, Opts) ->
-                        "brackets.erl" = filename:basename(File),
+    erlfmt:validator(fun(File, Opts) ->
+                        "minimal.erl" = filename:basename(File),
                         insert = proplists:get_value(pragma, Opts),
-                        {ok, []}
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args3 =
         rebar_state:command_parsed_args(init(#{require_pragma => false, insert_pragma => true}),
@@ -93,10 +72,10 @@ pragma(_Config) ->
     {ok, _} = rebar3_format_prv:do(Args3),
 
     % Otherwise it should be ignore
-    erlfmt:validator(fun(File, _, Opts) ->
-                        "brackets.erl" = filename:basename(File),
+    erlfmt:validator(fun(File, Opts) ->
+                        "minimal.erl" = filename:basename(File),
                         ignore = proplists:get_value(pragma, Opts),
-                        {ok, []}
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args4 =
         rebar_state:command_parsed_args(init(#{require_pragma => false, insert_pragma => false}),
@@ -105,19 +84,19 @@ pragma(_Config) ->
 
 width(_Config) ->
     % When there is no defined print_width
-    erlfmt:validator(fun(File, _, Opts) ->
-                        "src/brackets.erl" = File,
+    erlfmt:validator(fun(File, Opts) ->
+                        "src/minimal.erl" = File,
                         false = proplists:is_defined(width, Opts),
-                        {ok, []}
+                        {ok, ["-module(minimal).\n"], []}
                      end),
     Args1 = rebar_state:command_parsed_args(init(), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args1),
 
     % When print_width has a value, erlfmt's width should be it
-    erlfmt:validator(fun(File, _, Opts) ->
-                        "brackets.erl" = filename:basename(File),
+    erlfmt:validator(fun(File, Opts) ->
+                        "minimal.erl" = filename:basename(File),
                         50 = proplists:get_value(width, Opts, undefined),
-                        skip
+                        {skip, "-module(minimal).\n"}
                      end),
     Args2 = rebar_state:command_parsed_args(init(#{print_width => 50}), {[], something}),
     {ok, _} = rebar3_format_prv:do(Args2).
@@ -133,12 +112,7 @@ init(Opts) ->
     {ok, State1} =
         rebar3_format:init(
             rebar_state:new()),
-    Files = {files, ["src/brackets.erl"]},
+    Files = {files, ["src/minimal.erl"]},
     Formatter = {formatter, erlfmt_formatter},
     Out = {options, Opts},
     rebar_state:set(State1, format, [Files, Formatter, Out]).
-
-copy_file(File, OutFile) ->
-    ok = filelib:ensure_dir(OutFile),
-    {ok, _} = file:copy(File, OutFile),
-    ok.

--- a/test_app/after/src/minimal.erl
+++ b/test_app/after/src/minimal.erl
@@ -1,0 +1,1 @@
+-module(minimal).

--- a/test_app/src/minimal.erl
+++ b/test_app/src/minimal.erl
@@ -1,0 +1,1 @@
+-module(minimal).


### PR DESCRIPTION
[Fix #149] Add support for erlfmt `0.7.0` and drop support for `0.6.0` since the API differs way too much.

/cc @michalmuskala @awalterschulze 