### PR TITLE
[Fix #145] Report the results of --verify in a non-erlang-ish way

### DIFF
--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -51,8 +51,9 @@ do(State) ->
 %% @private
 -spec format_error(any()) -> string().
 format_error({unformatted_files, Files}) ->
-    Msg = "The following files are not properly formatted:\n~p",
-    io_lib:format(Msg, [Files]);
+    lists:foldr(fun(File, Acc) -> [Acc, File, $\n] end,
+                "The following files are not properly formatted:\n",
+                Files);
 format_error({erl_parse, File, Error}) ->
     Msg = "Error while parsing ~s: ~p.\n\tTry running with DEBUG=1 for "
           "more information",


### PR DESCRIPTION
[Fix #145] Report the results of --verify in a non-erlang-ish way…

```bash
===> The following files are not properly formatted:
src/weird.erl
src/unquoted_atoms.erl
src/syntax_tools_test.erl
```