### PR TITLE
[fix #144] handle more than 1 wildcard

### DIFF
--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -16,7 +16,7 @@ init(State) ->
                            [{files,
                              $f,
                              "files",
-                             string,
+                             [string],
                              "List of files and directories to be formatted"},
                             {verify, $v, "verify", boolean, "Just verify, don't format"},
                             {output,
@@ -74,8 +74,8 @@ get_action(Args) ->
 get_files(Args, State) ->
     Patterns =
         case lists:keyfind(files, 1, Args) of
-            {files, Wildcard} ->
-                [Wildcard];
+            {files, Files} ->
+                Files;
             false ->
                 FormatConfig = rebar_state:get(State, format, []),
                 case proplists:get_value(files, FormatConfig, undefined) of

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -16,7 +16,7 @@ init(State) ->
                            [{files,
                              $f,
                              "files",
-                             [string],
+                             string,
                              "List of files and directories to be formatted"},
                             {verify, $v, "verify", boolean, "Just verify, don't format"},
                             {output,
@@ -72,18 +72,19 @@ get_action(Args) ->
 
 -spec get_files(proplists:proplist(), rebar_state:t()) -> [file:filename_all()].
 get_files(Args, State) ->
+    FilesFromArgs = [Value || {Key, Value} <- Args, Key == files],
     Patterns =
-        case lists:keyfind(files, 1, Args) of
-            {files, Files} ->
-                Files;
-            false ->
+        case FilesFromArgs of
+            [] ->
                 FormatConfig = rebar_state:get(State, format, []),
                 case proplists:get_value(files, FormatConfig, undefined) of
                     undefined ->
                         ["src/**/*.[he]rl"];
                     Wildcards ->
                         Wildcards
-                end
+                end;
+            Files ->
+                Files
         end,
     [File || Pattern <- Patterns, File <- filelib:wildcard(Pattern)].
 


### PR DESCRIPTION
I added a way to pass multiple files/wildcards to rebar3_format.  We can try it running something like this:
```
$ rebar3 format --files src/file1.erl --files src/file2.erl
```

Note that we have to write `--files` for each different file/wildcard because [getopt](https://github.com/jcomellas/getopt#argument-types) doesn't handle list arguments.

## How to test it
To test it i created a `_checkouts` directory inside `test_app/` and cloned my branch there.
Then I ran
```
$ rebar3 deps
$ rebar3 format --files src/break.erl --files src/catch_test.erl
```
