### PR TITLE
Fix #180: erlfmt 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If you want to use [@whatsapp](https://github.com/whatsapp)'s [erlfmt](https://g
 ```
 
 #### Compatibility Note
-`erlfmt_formatter` is compatible with version `v0.7.0` of `erlfmt`, which is currently available at [hex.pm](https://hex.pm/packages/erlfmt/0.7.0).
+`erlfmt_formatter` is compatible with version `v0.7.0` and `v0.8.0` of `erlfmt`, which are currently available at [hex.pm](https://hex.pm/packages/erlfmt).
 
 
 ## Implementing your own Formatter

--- a/src/formatters/erlfmt_formatter.erl
+++ b/src/formatters/erlfmt_formatter.erl
@@ -37,7 +37,9 @@ format_file(File, nostate, OptionsMap) ->
             undefined ->
                 [{pragma, Pragma}];
             Width ->
-                [{width, Width}, {pragma, Pragma}]
+                [{width, Width}, % support for v0.7.0
+                 {print_width, Width},
+                 {pragma, Pragma}]
         end,
 
     {Result, NewCode} =


### PR DESCRIPTION
Fix #180: Add support for `erlfmt` `0.8.0`, without losing support for `0.7.0` just yet.

/cc @michalmuskala @awalterschulze