### PR TITLE
[Fix #148] Add options to space out parentheses and curly braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The plugin supports the following configuration options in the `format` section 
             * The default value is `false`.
         + `spaces_around_fields` (`boolean()`):
             * Specifies if an expression such as `#{a => map, "with" => "fields"}` should be formatted as `#{ a => map, "with" => "fields" }`.
-            * This parameter works on map and record expressions and types, but of course it doesn't affect tuples.
+            * This parameter works on map and record expressions and types, but it doesn't affect tuples.
             * The default value is `false`.
         + `preserve_empty_lines` (`boolean()`):
             * Specifies if blank lines between statements should be preserved when formatting.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The plugin supports the following configuration options in the `format` section 
             * The default value is `false`.
         + `spaces_around_arguments` (`boolean()`):
             * Specifies if an expression such as `a_function:call("with", "arguments")` should be formatted as `a_function:call( "with", "argments" )`.
-            * This parameter doesn't apply to **every expression** written within parenetheses (e.g. attributes, function types, etc.). It only applies to function calls with at least one parameter.
+            * This parameter doesn't apply to **every expression** with arguments (e.g. attributes, function types, etc.). It only applies to function calls (i.e. _applications_).
             * Although this configuration doesn't override the value of `inline_qualified_function_composition`, we strongly recommend you to use `inline_qualified_function_composition => true` if you use `spaces_within_parentheses => true`.
             * The default value is `false`.
         + `spaces_around_fields` (`boolean()`):

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ The plugin supports the following configuration options in the `format` section 
         + `parenthesize_infix_operations` (`boolean()`):
             * Specifies if parentheses should be added around composed [infix operations](https://erlang.org/doc/reference_manual/expressions.html#arithmetic-expressions) to avoid confusion around precedence.
             * The default value is `false`.
+        + `spaces_around_arguments` (`boolean()`):
+            * Specifies if an expression such as `a_function:call("with", "arguments")` should be formatted as `a_function:call( "with", "argments" )`.
+            * This parameter doesn't apply to **every expression** written within parenetheses (e.g. attributes, function types, etc.). It only applies to function calls with at least one parameter.
+            * Although this configuration doesn't override the value of `inline_qualified_function_composition`, we strongly recommend you to use `inline_qualified_function_composition => true` if you use `spaces_within_parentheses => true`.
+            * The default value is `false`.
+        + `spaces_around_fields` (`boolean()`):
+            * Specifies if an expression such as `#{a => map, "with" => "fields"}` should be formatted as `#{ a => map, "with" => "fields" }`.
+            * This parameter works on map and record expressions and types, but of course it doesn't affect tuples.
+            * The default value is `false`.
         + `preserve_empty_lines` (`boolean()`):
             * Specifies if blank lines between statements should be preserved when formatting.
             * Keep in mind that blank lines between clauses, between items in tuples, lists, etc, between attributes, and so on will not be affected by this configuration and therefore they'll be unconditionally removed.

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -67,7 +67,7 @@
          inline_qualified_function_composition = false :: boolean(),
          inline_expressions = false :: boolean(),
          spaces_within_parentheses = false :: boolean(),
-         spaces_around_fields = true :: boolean(),
+         spaces_around_fields = false :: boolean(),
          unquote_atoms = true :: boolean(),
          parenthesize_infix_operations = false :: boolean(),
          empty_lines = [] :: [pos_integer()],
@@ -158,7 +158,7 @@ layout(Node, EmptyLines, Options) ->
                   maps:get(parenthesize_infix_operations, Options, false),
               unquote_atoms = maps:get(unquote_atoms, Options, true),
               spaces_within_parentheses = maps:get(spaces_within_parentheses, Options, false),
-              spaces_around_fields = maps:get(spaces_around_fields, Options, true),
+              spaces_around_fields = maps:get(spaces_around_fields, Options, false),
               empty_lines = EmptyLines,
               encoding = maps:get(encoding, Options, epp:default_encoding())}).
 
@@ -1372,8 +1372,11 @@ number_from_text(Text, Default) ->
             Text
     end.
 
-lay_fields(Opening, Exprs, Ctxt = #ctxt{spaces_around_fields = _}, Fun) ->
-    beside(Opening, beside(lay_fields(Exprs, Ctxt, Fun), lay_text_float("}"))).
+lay_fields(Opening, Exprs, Ctxt = #ctxt{spaces_around_fields = false}, Fun) ->
+    beside(Opening, beside(lay_fields(Exprs, Ctxt, Fun), lay_text_float("}")));
+lay_fields(Opening, Exprs, Ctxt = #ctxt{spaces_around_fields = true}, Fun) ->
+    par([par([Opening, lay_fields(Exprs, Ctxt, Fun)], Ctxt#ctxt.break_indent),
+         lay_text_float("}")]).
 
 lay_fields(Exprs, Ctxt = #ctxt{inline_fields = {when_over, N}}, Fun)
     when length(Exprs) > N ->

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -66,7 +66,7 @@
          inline_clause_bodies = false :: boolean(),
          inline_qualified_function_composition = false :: boolean(),
          inline_expressions = false :: boolean(),
-         spaces_within_parentheses = false :: boolean(),
+         spaces_around_arguments = false :: boolean(),
          spaces_around_fields = false :: boolean(),
          unquote_atoms = true :: boolean(),
          parenthesize_infix_operations = false :: boolean(),
@@ -157,7 +157,7 @@ layout(Node, EmptyLines, Options) ->
               parenthesize_infix_operations =
                   maps:get(parenthesize_infix_operations, Options, false),
               unquote_atoms = maps:get(unquote_atoms, Options, true),
-              spaces_within_parentheses = maps:get(spaces_within_parentheses, Options, false),
+              spaces_around_arguments = maps:get(spaces_around_arguments, Options, false),
               spaces_around_fields = maps:get(spaces_around_fields, Options, false),
               empty_lines = EmptyLines,
               encoding = maps:get(encoding, Options, epp:default_encoding())}).
@@ -302,7 +302,7 @@ lay_no_comments(Node, Ctxt) ->
         application ->
             lay_application(erl_syntax:application_operator(Node),
                             erl_syntax:application_arguments(Node),
-                            Ctxt#ctxt.spaces_within_parentheses,
+                            Ctxt#ctxt.spaces_around_arguments,
                             Ctxt);
         match_expr ->
             {PrecL, Prec, PrecR} = inop_prec('='),

--- a/test_app/after/src/function_composition.erl
+++ b/test_app/after/src/function_composition.erl
@@ -10,7 +10,7 @@ local_calls(should, be, unaffected) ->
 external_calls() ->
     should:be(
         indented:every(
-            singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+            singe:time([{even, "when", including}]), local_calls(?AND_MACROS, #{}, undefined)),
         local_calls(?MACROS(should), be, unaffected)),
     the_idea_is_to_force:long_module_and_function_names(
         to_be_put:in_the_next_row([{so, that},

--- a/test_app/after/src/function_composition_inline.erl
+++ b/test_app/after/src/function_composition_inline.erl
@@ -10,7 +10,7 @@ local_calls(should, be, unaffected) ->
     g(f(b, h(a), w(x(y)))).
 
 external_calls() ->
-    shouldnt:be(indented:every(singe:time([{even, "when", inlcuding}]),
+    shouldnt:be(indented:every(singe:time([{even, "when", including}]),
                                local_calls(?AND_MACROS, #{}, undefined)),
                 local_calls(?MACROS(should), be, unaffected)),
     the_idea_is_not_to_force:long_module_and_function_names(to_be_put:in_the_next_row([{even,

--- a/test_app/after/src/function_composition_spaces.erl
+++ b/test_app/after/src/function_composition_spaces.erl
@@ -12,7 +12,7 @@ local_calls(should, be, unaffected) ->
 external_calls() ->
     shouldnt:be(
         indented:every(
-            singe:time( [{even, "when", inlcuding}] ), local_calls( ?AND_MACROS, #{}, undefined )
+            singe:time( [{even, "when", including}] ), local_calls( ?AND_MACROS, #{}, undefined )
         ),
         local_calls( ?MACROS(should), be, unaffected )
     ),

--- a/test_app/after/src/function_composition_spaces.erl
+++ b/test_app/after/src/function_composition_spaces.erl
@@ -1,7 +1,6 @@
 -module(function_composition_spaces).
 
--format #{inline_qualified_function_composition => true,
-          spaces_within_parentheses => true}.
+-format #{inline_qualified_function_composition => true, spaces_around_arguments => true}.
 
 -export([local_calls/3, external_calls/0]).
 

--- a/test_app/after/src/function_composition_spaces.erl
+++ b/test_app/after/src/function_composition_spaces.erl
@@ -1,0 +1,23 @@
+-module(function_composition_spaces).
+
+-format #{inline_qualified_function_composition => true,
+          spaces_within_parentheses => true}.
+
+-export([local_calls/3, external_calls/0]).
+
+-type t() :: only:function(application:is(affected(by:this(change)))) | not_types.
+
+local_calls(should, be, unaffected) ->
+    g( f( b, h( a ), w( x( y ) ) ) ).
+
+external_calls() ->
+    shouldnt:be(
+        indented:every(
+            singe:time( [{even, "when", inlcuding}] ), local_calls( ?AND_MACROS, #{}, undefined )
+        ),
+        local_calls( ?MACROS(should), be, unaffected )
+    ),
+    but:the(
+        whole:code( [{should, be}, "nicely", <<"indented">>, now:that(), we, have, spaces] )
+    ),
+    within( the( parenthesis() ) ).

--- a/test_app/after/src/spaces_around_fields.erl
+++ b/test_app/after/src/spaces_around_fields.erl
@@ -1,0 +1,36 @@
+-module(spaces_around_fields).
+
+-format #{ spaces_around_fields => true }.
+
+-export([f/1]).
+
+-record(a, {small, with}).
+
+-type a() :: #a{ small :: record, with :: {some, fields} }.
+-type b() ::
+    #{
+        a => small,
+        map => with,
+        some => fields
+    }.
+
+f(A) ->
+    W = #just{ one = field },
+    X = #a{ small = record, with = {some, fields} },
+    Y = #{
+            a => small,
+            map => with,
+            some => fields
+        },
+    #{
+        one =>
+            {[very, W],
+             [large, X],
+             <<field, Y>>,
+             that,
+             exceeds,
+             a,
+             single,
+             line,
+             [no, matter, "what", you, do]}
+    }.

--- a/test_app/src/function_composition.erl
+++ b/test_app/src/function_composition.erl
@@ -8,7 +8,7 @@ local_calls(should, be, unaffected) ->
     g(f(b, h(a), w(x(y)))).
 
 external_calls() ->
-    should:be(indented:every(singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+    should:be(indented:every(singe:time([{even, "when", including}]), local_calls(?AND_MACROS, #{}, undefined)),
         local_calls(?MACROS(should), be, unaffected)),
     the_idea_is_to_force:long_module_and_function_names(to_be_put:in_the_next_row([{so, that}, "their", <<"parameters">>, can:be(), read, more, easily])),
     this_one(will:be(more(complex:since(it:combines(), local:and_remote(calls))), hopefully:it(is(a, rare, thing)))).

--- a/test_app/src/function_composition_inline.erl
+++ b/test_app/src/function_composition_inline.erl
@@ -10,7 +10,7 @@ local_calls(should, be, unaffected) ->
     g(f(b, h(a), w(x(y)))).
 
 external_calls() ->
-    shouldnt:be(indented:every(singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+    shouldnt:be(indented:every(singe:time([{even, "when", including}]), local_calls(?AND_MACROS, #{}, undefined)),
         local_calls(?MACROS(should), be, unaffected)),
     the_idea_is_not_to_force:long_module_and_function_names(to_be_put:in_the_next_row([{even, 'when'}, "their", <<"parameters">>, can:be(), read, more, easily])),
     this_one(will:be(more(complex:since(it:combines(), local:and_remote(calls))), hopefully:it(is(a, rare, thing)))).

--- a/test_app/src/function_composition_spaces.erl
+++ b/test_app/src/function_composition_spaces.erl
@@ -10,7 +10,7 @@ local_calls(should, be, unaffected) ->
     g(f(b, h(a), w(x(y)))).
 
 external_calls() ->
-    shouldnt:be(indented:every(singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+    shouldnt:be(indented:every(singe:time([{even, "when", including}]), local_calls(?AND_MACROS, #{}, undefined)),
         local_calls(?MACROS(should), be, unaffected)),
     but:the(whole:code([{should, be}, "nicely", <<"indented">>, now:that(), we, have, spaces])),
     within(the(parenthesis())).

--- a/test_app/src/function_composition_spaces.erl
+++ b/test_app/src/function_composition_spaces.erl
@@ -1,6 +1,6 @@
 -module(function_composition_spaces).
 
--format #{spaces_within_parentheses => true, inline_qualified_function_composition => true}.
+-format #{spaces_around_arguments => true, inline_qualified_function_composition => true}.
 
 -export([local_calls/3, external_calls/0]).
 

--- a/test_app/src/function_composition_spaces.erl
+++ b/test_app/src/function_composition_spaces.erl
@@ -1,0 +1,16 @@
+-module(function_composition_spaces).
+
+-format #{spaces_within_parentheses => true, inline_qualified_function_composition => true}.
+
+-export([local_calls/3, external_calls/0]).
+
+-type t() :: only:function(application:is(affected(by:this(change)))) | not_types.
+
+local_calls(should, be, unaffected) ->
+    g(f(b, h(a), w(x(y)))).
+
+external_calls() ->
+    shouldnt:be(indented:every(singe:time([{even, "when", inlcuding}]), local_calls(?AND_MACROS, #{}, undefined)),
+        local_calls(?MACROS(should), be, unaffected)),
+    but:the(whole:code([{should, be}, "nicely", <<"indented">>, now:that(), we, have, spaces])),
+    within(the(parenthesis())).

--- a/test_app/src/spaces_around_fields.erl
+++ b/test_app/src/spaces_around_fields.erl
@@ -1,0 +1,16 @@
+-module(spaces_around_fields).
+
+-format #{spaces_around_fields => true}.
+
+-export [f/1].
+
+-record(a, {small, with}).
+
+-type a() :: #a{small :: record, with :: {some, fields}}.
+-type b() :: #{a => small, map => with, some => fields}.
+
+f(A) ->
+    W = #just{one = field},
+    X = #a{small = record, with = {some, fields}},
+    Y = #{a => small, map => with, some => fields},
+    #{one => {[very, W], [large, X], <<field, Y>>, that, exceeds, a, single, line, [no, matter, "what", you, do]}}.


### PR DESCRIPTION
[Fix #148] Add options to space out parentheses and curly braces.

I'm actually, personally, a huge fan of…

```erlang
-format #{
    spaces_around_fields => true,
    spaces_around_arguments => true,
    inline_qualified_function_composition => true
}.
```

I think that having some extra spaces in things like `a( function:call( #{ with => parameters } ) )` is a price I'm willing to pay in order to have a consistent indentation of function calls and field lists.
Stuff like…

```erlang
this() ->
    #{
        is => exactly,
        how =>
            i:would(
                write,
                my,
                code
            )
    }.
```

I kept `false` as the default in those fields, tho… mostly to avoid _controversies_ around `stuff:like( this ) or this( )`.