### PR TITLE
Don't crash on weird macros

### DIFF
--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -37,7 +37,7 @@ format(File, Formatter, Opts) ->
     end.
 
 get_ast(File) ->
-    case ktn_dodger:parse_file(File, [{scan_opts, [text]}]) of
+    case ktn_dodger:parse_file(File, [{scan_opts, [text]}, no_fail]) of
         {ok, AST} ->
             case [Error || {error, Error} <- AST] of
                 [] ->

--- a/test_app/after/src/macros.erl
+++ b/test_app/after/src/macros.erl
@@ -26,3 +26,9 @@ another_hidden_function() ->
     is_hidden.
 
 -endif.
+
+-define(WITH_ARGS(X), #{name := X}).
+-define(NO_ARGS(), result).
+-define(NO_PARENS, no_parens).
+
+other_function ( ? NO_ARGS ( ) , ? NO_PARENS , ? WITH_ARGS ( X ) , ? WITH_ARGS ( ? WITH_ARGS ( ? NO_ARGS ( ) ) ) ) -> { ? NO_ARGS ( ) , ? NO_PARENS , X } .

--- a/test_app/src/macros.erl
+++ b/test_app/src/macros.erl
@@ -25,3 +25,11 @@ another_hidden_function() ->
 
         is_hidden.
 -endif.
+
+-define(WITH_ARGS(X), #{name := X}).
+-define(NO_ARGS(), result).
+-define(NO_PARENS, no_parens).
+
+other_function(?NO_ARGS(), ?NO_PARENS, ?WITH_ARGS(X), ?WITH_ARGS(?WITH_ARGS(?NO_ARGS()))) ->
+    {?NO_ARGS(), ?NO_PARENS, X}.
+


### PR DESCRIPTION
The code ends up extremely ugly since it's "formatted" directly by `ktn_dodge`, but at least it's semantically correct.