### PR TITLE
[Fix #210] Actually use arity qualifiers for inlining directives.

### DIFF
--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -473,7 +473,11 @@ lay_no_comments(Node, Ctxt) ->
                             Ctxt1#ctxt{force_indentation = true,
                                        inline_items = Ctxt1#ctxt.inline_attributes},
                         lay_application(N, Args, Ctxt2);
-                    Tag when Tag =:= dialyzer; Tag =:= mixin; Tag =:= ignore_xref; Tag =:= inline ->
+                    Tag
+                        when Tag =:= dialyzer;
+                             Tag =:= mixin;
+                             Tag =:= ignore_xref;
+                             Tag =:= compile ->
                         %% We need to convert 2-tuples to arity qualifiers here
                         %% because the parser doesn't recognize them as such.
                         Ctxt2 = Ctxt1#ctxt{force_arity_qualifiers = true},

--- a/test_app/after/src/dialyzer.erl
+++ b/test_app/after/src/dialyzer.erl
@@ -9,6 +9,6 @@
 
 -mixin([{a_module, [new/1, feature/2, log_params/2]}]).
 
--inline([something/4]).
+-compile({inline, [something/4]}).
 
 -ignore_xref(metric/4).

--- a/test_app/src/dialyzer.erl
+++ b/test_app/src/dialyzer.erl
@@ -9,6 +9,6 @@
 
 -mixin([{a_module, [new/1, feature/2, log_params/2]}]).
 
--inline([something/4]).
+-compile({inline, [something/4]}).
 
 -ignore_xref(metric/4).


### PR DESCRIPTION
Fixes #210 since `inline` is not an attribute on its own, it's a parameter for `compile`.