### PR TITLE
[Fix #185] Place infix operators in columns

### DIFF
--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -1304,13 +1304,12 @@ move_comments(Name, [Arg0 | Args]) ->
 is_qualified_function_composition(_, []) ->
     false;
 is_qualified_function_composition(Outside, [FirstArg | _]) ->
-    module_qualifier == erl_syntax:type(Outside)
+    erl_syntax:type(Outside) == module_qualifier
     andalso erl_syntax:type(FirstArg) == application
     andalso
-        module_qualifier
-        ==
-            erl_syntax:type(
-                erl_syntax:application_operator(FirstArg)).
+        erl_syntax:type(
+            erl_syntax:application_operator(FirstArg))
+        == module_qualifier.
 
 seq([H], _Separator, Ctxt, Fun) ->
     [Fun(H, Ctxt)];

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -1198,8 +1198,8 @@ is_last_and_before_empty_line(H, [], #ctxt{empty_lines = EmptyLines}) ->
     end;
 is_last_and_before_empty_line(H, [H2 | _], #ctxt{empty_lines = EmptyLines}) ->
     try
-        (erl_syntax:get_pos(H2) - erl_syntax:get_pos(H) >= 2) and
-            sets:is_element(erl_syntax:get_pos(H) + 1, EmptyLines)
+        (erl_syntax:get_pos(H2) - erl_syntax:get_pos(H) >= 2)
+        and sets:is_element(erl_syntax:get_pos(H) + 1, EmptyLines)
     catch
         error:badarith -> false
     end.

--- a/test_app/after/src/indent_18.erl
+++ b/test_app/after/src/indent_18.erl
@@ -17,8 +17,9 @@
           they:also(should:be(indented_using:break_indent(1)))}).
 
 infix_expr() ->
- this:infix(expression) ++
-  should:be(indented) ++ using:break_indent(1).
+ this:infix(expression)
+ ++ should:be(indented)
+ ++ using:break_indent(1).
 
 prefix_expr() ->
  ThisPrefixExpressionShould =
@@ -134,6 +135,6 @@ when_clause(A, B, C)
    indented_using:sub_indent(1)));
 when_clause(Along, Blonb, Clong)
  when is_integer(Along),
-      Along >= Blong andalso
-       Clong rem Along =:= Blong ->
+      Along >= Blong
+      andalso Clong rem Along =:= Blong ->
  here:should(happen, the, same, thing).

--- a/test_app/after/src/indent_81.erl
+++ b/test_app/after/src/indent_81.erl
@@ -17,9 +17,9 @@
                  they:also(should:be(indented_using:break_indent(8)))}).
 
 infix_expr() ->
-        this:infix(expression) ++
-                should:be(indented) ++
-                        using:break_indent(8).
+        this:infix(expression)
+        ++ should:be(indented)
+        ++ using:break_indent(8).
 
 prefix_expr() ->
         ThisPrefixExpressionShould =
@@ -142,6 +142,6 @@ when_clause(A, B, C)
                         indented_using:sub_indent(1)));
 when_clause(Along, Blonb, Clong)
         when is_integer(Along),
-             Along >= Blong andalso
-                     Clong rem Along =:= Blong ->
+             Along >= Blong
+             andalso Clong rem Along =:= Blong ->
         here:should(happen, the, same, thing).

--- a/test_app/after/src/inline_items.erl
+++ b/test_app/after/src/inline_items.erl
@@ -277,8 +277,13 @@ long_arglist(X1,
              VeryVeryLongName1,
              VeryVeryLongName2,
              VeryVeryLongName3) ->
-    X1 + X2 + X3 + Y1 + VeryVeryLongName1 + VeryVeryLongName2 +
-        VeryVeryLongName3.
+    X1
+    + X2
+    + X3
+    + Y1
+    + VeryVeryLongName1
+    + VeryVeryLongName2
+    + VeryVeryLongName3.
 
 short() ->
     [these,

--- a/test_app/after/src/operator_indentation.erl
+++ b/test_app/after/src/operator_indentation.erl
@@ -1,0 +1,95 @@
+-module(operator_indentation).
+
+a_large_predicate(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+    andalso PredTwo
+    andalso AValue =:= something
+    andalso
+        something:potentially(
+            very:long(
+                that:needs(indenting)))
+    orelse
+        PredOne
+        and PredTwo
+        and something:potentially(very, extremely, long)
+        and (AValue =:= something_else)
+    orelse
+        PredOne
+        andalso
+            something:very_long(based,
+                                on,
+                                PredOne,
+                                "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+        andalso AValue =:= something_other
+        andalso
+            something:potentially(
+                very:long(
+                    that:needs(indenting))).
+
+in_a_list(PredOne, PredTwo, AValue) ->
+    [something:very_long(based,
+                         on,
+                         PredOne,
+                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+     andalso PredTwo
+     andalso AValue =:= something
+     andalso
+         something:potentially(
+             very:long(
+                 that:needs(indenting))),
+     PredOne
+     and PredTwo
+     and something:potentially(very, extremely, long)
+     and (AValue =:= something_else),
+     PredOne
+     andalso
+         something:very_long(based,
+                             on,
+                             PredOne,
+                             "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+     andalso AValue =:= something_other
+     andalso
+         something:potentially(
+             very:long(
+                 that:needs(indenting)))].
+
+precedence(One, Two, Three) ->
+    careful:with(the,
+                 precedence,
+                 ((One -- Two) -- Three) -- One,
+                 is_not,
+                 One -- (Two -- Three) -- One,
+                 nor,
+                 One -- Two -- Three -- One).
+
+other_operators(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+    ++ PredTwo
+    ++ AValue xor something
+    ++
+        something:potentially(
+            very:long(
+                that:needs(indenting)))
+        --
+            PredOne
+            + PredTwo
+            + something:potentially(very, extremely, long)
+            + AValue band something_else
+        --
+            PredOne
+            ++
+                something:very_long(based,
+                                    on,
+                                    PredOne,
+                                    "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+            ++ AValue band something_other
+            ++
+                something:potentially(
+                    very:long(
+                        that:needs(indenting))).

--- a/test_app/after/src/operator_indentation_with_parens.erl
+++ b/test_app/after/src/operator_indentation_with_parens.erl
@@ -1,0 +1,100 @@
+-module(operator_indentation_with_parens).
+
+-format #{parenthesize_infix_operations => true}.
+
+a_large_predicate(PredOne, PredTwo, AValue) ->
+    (something:very_long(based,
+                         on,
+                         PredOne,
+                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+     andalso
+         (PredTwo
+          andalso
+              ((AValue =:= something)
+               andalso
+                   something:potentially(
+                       very:long(
+                           that:needs(indenting))))))
+    orelse
+        ((((PredOne and PredTwo) and something:potentially(very, extremely, long))
+          and (AValue =:= something_else))
+         orelse
+             (PredOne
+              andalso
+                  (something:very_long(based,
+                                       on,
+                                       PredOne,
+                                       "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                   andalso
+                       ((AValue =:= something_other)
+                        andalso
+                            something:potentially(
+                                very:long(
+                                    that:needs(indenting))))))).
+
+in_a_list(PredOne, PredTwo, AValue) ->
+    [something:very_long(based,
+                         on,
+                         PredOne,
+                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+     andalso
+         (PredTwo
+          andalso
+              ((AValue =:= something)
+               andalso
+                   something:potentially(
+                       very:long(
+                           that:needs(indenting))))),
+     ((PredOne and PredTwo) and something:potentially(very, extremely, long))
+     and (AValue =:= something_else),
+     PredOne
+     andalso
+         (something:very_long(based,
+                              on,
+                              PredOne,
+                              "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+          andalso
+              ((AValue =:= something_other)
+               andalso
+                   something:potentially(
+                       very:long(
+                           that:needs(indenting)))))].
+
+precedence(One, Two, Three) ->
+    careful:with(the,
+                 precedence,
+                 ((One -- Two) -- Three) -- One,
+                 is_not,
+                 One -- ((Two -- Three) -- One),
+                 nor,
+                 One -- (Two -- (Three -- One))).
+
+other_operators(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+    ++
+        (PredTwo
+         ++
+             ((AValue xor something)
+              ++
+                  (something:potentially(
+                       very:long(
+                           that:needs(indenting)))
+                   --
+                       ((((PredOne + PredTwo) + something:potentially(very, extremely, long))
+                         + (AValue band something_else))
+                        --
+                            (PredOne
+                             ++
+                                 (something:very_long(based,
+                                                      on,
+                                                      PredOne,
+                                                      "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                                  ++
+                                      ((AValue band something_other)
+                                       ++
+                                           something:potentially(
+                                               very:long(
+                                                   that:needs(indenting)))))))))).

--- a/test_app/after/src/others.erl
+++ b/test_app/after/src/others.erl
@@ -107,16 +107,16 @@ multi_try_expr() ->
     end.
 
 long_case_of() ->
-    case whereis(ServerAndTable) =/= undefined orelse
-             counter_sup:start_child([ServerAndTable, Name])
+    case whereis(ServerAndTable) =/= undefined
+         orelse counter_sup:start_child([ServerAndTable, Name])
     of
         thing ->
             thong
     end.
 
 long_try_of() ->
-    try whereis(ServerAndTable) =/= undefined orelse
-            counter_sup:start_child([ServerAndTable, Name])
+    try whereis(ServerAndTable) =/= undefined
+        orelse counter_sup:start_child([ServerAndTable, Name])
     of
         thing ->
             thong

--- a/test_app/after/src/parentheses_yes.erl
+++ b/test_app/after/src/parentheses_yes.erl
@@ -8,8 +8,8 @@ numbers() ->
     Number = (((+1 + 2) + 3) - ((4 * 5) / 6)) + ((7 * 8) / (9 - 10)),
     Modulo = (100 div (7 div 3)) rem 5,
     Bits =
-        ((((bnot 2#001 band 2#010) bor 2#100) bxor 2#101) bsl 2#110) bsr
-            (2#111 band (2#100 bxor 2#101)),
+        ((((bnot 2#001 band 2#010) bor 2#100) bxor 2#101) bsl 2#110)
+        bsr (2#111 band (2#100 bxor 2#101)),
     (Number + Modulo) - Bits.
 
 booleans(A, B) when not B, A; A xor B ->

--- a/test_app/src/operator_indentation.erl
+++ b/test_app/src/operator_indentation.erl
@@ -1,0 +1,86 @@
+-module(operator_indentation).
+
+a_large_predicate(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+        andalso
+        PredTwo andalso
+            AValue =:= something andalso
+                something:potentially(
+                    very:long(
+                        that:needs(indenting)))
+        orelse
+        PredOne and PredTwo and something:potentially(very, extremely, long) and
+            (AValue =:= something_else)
+            orelse
+            PredOne andalso
+                something:very_long(based,
+                                    on,
+                                    PredOne,
+                                    "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                    andalso
+                    AValue =:= something_other andalso
+                        something:potentially(
+                            very:long(
+                                that:needs(indenting))).
+
+in_a_list(PredOne, PredTwo, AValue) ->
+    [something:very_long(based,
+                         on,
+                         PredOne,
+                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+         andalso
+         PredTwo andalso
+             AValue =:= something andalso
+                 something:potentially(
+                     very:long(
+                         that:needs(indenting))),
+     PredOne and PredTwo and something:potentially(very, extremely, long) and
+         (AValue =:= something_else),
+     PredOne andalso
+         something:very_long(based,
+                             on,
+                             PredOne,
+                             "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+             andalso
+             AValue =:= something_other andalso
+                 something:potentially(
+                     very:long(
+                         that:needs(indenting)))].
+
+precedence(One, Two, Three) ->
+    careful:with(the,
+                 precedence,
+                 ((One -- Two) -- Three) -- One,
+                 is_not,
+                 One -- (Two -- Three) -- One,
+                 nor,
+                 One -- Two -- Three -- One).
+
+other_operators(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+        ++
+        PredTwo ++
+            AValue xor something ++
+                something:potentially(
+                    very:long(
+                        that:needs(indenting)))
+                    --
+                    PredOne + PredTwo + something:potentially(very, extremely, long) +
+                        AValue band something_else
+                        --
+                        PredOne ++
+                            something:very_long(based,
+                                                on,
+                                                PredOne,
+                                                "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                                ++
+                                AValue band something_other ++
+                                    something:potentially(
+                                        very:long(
+                                            that:needs(indenting))).

--- a/test_app/src/operator_indentation_with_parens.erl
+++ b/test_app/src/operator_indentation_with_parens.erl
@@ -1,0 +1,88 @@
+-module(operator_indentation_with_parens).
+
+-format #{parenthesize_infix_operations => true}.
+
+a_large_predicate(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+        andalso
+        PredTwo andalso
+            AValue =:= something andalso
+                something:potentially(
+                    very:long(
+                        that:needs(indenting)))
+        orelse
+        PredOne and PredTwo and something:potentially(very, extremely, long) and
+            (AValue =:= something_else)
+            orelse
+            PredOne andalso
+                something:very_long(based,
+                                    on,
+                                    PredOne,
+                                    "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                    andalso
+                    AValue =:= something_other andalso
+                        something:potentially(
+                            very:long(
+                                that:needs(indenting))).
+
+in_a_list(PredOne, PredTwo, AValue) ->
+    [something:very_long(based,
+                         on,
+                         PredOne,
+                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+         andalso
+         PredTwo andalso
+             AValue =:= something andalso
+                 something:potentially(
+                     very:long(
+                         that:needs(indenting))),
+     PredOne and PredTwo and something:potentially(very, extremely, long) and
+         (AValue =:= something_else),
+     PredOne andalso
+         something:very_long(based,
+                             on,
+                             PredOne,
+                             "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+             andalso
+             AValue =:= something_other andalso
+                 something:potentially(
+                     very:long(
+                         that:needs(indenting)))].
+
+precedence(One, Two, Three) ->
+    careful:with(the,
+                 precedence,
+                 ((One -- Two) -- Three) -- One,
+                 is_not,
+                 One -- (Two -- Three) -- One,
+                 nor,
+                 One -- Two -- Three -- One).
+
+other_operators(PredOne, PredTwo, AValue) ->
+    something:very_long(based,
+                        on,
+                        PredOne,
+                        "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+        ++
+        PredTwo ++
+            AValue xor something ++
+                something:potentially(
+                    very:long(
+                        that:needs(indenting)))
+                    --
+                    PredOne + PredTwo + something:potentially(very, extremely, long) +
+                        AValue band something_else
+                        --
+                        PredOne ++
+                            something:very_long(based,
+                                                on,
+                                                PredOne,
+                                                "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                                ++
+                                AValue band something_other ++
+                                    something:potentially(
+                                        very:long(
+                                            that:needs(indenting))).


### PR DESCRIPTION
> [Fix #185] Place infix operators in columns

Let me know if you want to put this new formatting behavior behind a configuration option, although I think it will be more maintainable to keep it as the default.