### PR TITLE
[Fix #219] Don't indent right after an operator

### DIFF
--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -300,10 +300,9 @@ lay_no_comments(Node, Ctxt) ->
             D1 = lay(Pattern, set_prec(Ctxt, PrecL)),
             D2 = lay(erl_syntax:match_expr_body(Node), set_prec(Ctxt, PrecR)),
             D3 = case erl_syntax:type(Pattern) == underscore
-                      orelse
-                          erl_syntax:type(Pattern) == variable
-                          andalso
-                              length(erl_syntax:variable_literal(Pattern)) < Ctxt#ctxt.break_indent
+                      orelse erl_syntax:type(Pattern) == variable
+                             andalso length(erl_syntax:variable_literal(Pattern))
+                                     < Ctxt#ctxt.break_indent
                  of
                      true -> %% Single short variable on the left, don't nest
                          follow(beside(D1, lay_text_float(" =")), D2, Ctxt#ctxt.break_indent);
@@ -1285,7 +1284,7 @@ adjust_infix_expr_pars([Doc | Docs], Ctxt) ->
 adjust_infix_expr_pars([], _, Acc) ->
     lists:reverse(Acc);
 adjust_infix_expr_pars([OpDoc, ExprDoc | Docs], Ctxt, Acc) ->
-    adjust_infix_expr_pars(Docs, Ctxt, [par([OpDoc, ExprDoc], Ctxt#ctxt.break_indent) | Acc]).
+    adjust_infix_expr_pars(Docs, Ctxt, [beside(beside(OpDoc, text(" ")), ExprDoc) | Acc]).
 
 %% @doc If the name has postcomments and/or the first argument has precomments
 %%      they get moved *too much*. So we convert them all into precomments, since
@@ -1310,10 +1309,9 @@ is_qualified_function_composition(_, []) ->
 is_qualified_function_composition(Outside, [FirstArg | _]) ->
     erl_syntax:type(Outside) == module_qualifier
     andalso erl_syntax:type(FirstArg) == application
-    andalso
-        erl_syntax:type(
-            erl_syntax:application_operator(FirstArg))
-        == module_qualifier.
+    andalso erl_syntax:type(
+                erl_syntax:application_operator(FirstArg))
+            == module_qualifier.
 
 seq([H], _Separator, Ctxt, Fun) ->
     [Fun(H, Ctxt)];

--- a/test_app/after/src/operator_indentation.erl
+++ b/test_app/after/src/operator_indentation.erl
@@ -7,27 +7,22 @@ a_large_predicate(PredOne, PredTwo, AValue) ->
                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
     andalso PredTwo
     andalso AValue =:= something
-    andalso
-        something:potentially(
-            very:long(
-                that:needs(indenting)))
-    orelse
-        PredOne
-        and PredTwo
-        and something:potentially(very, extremely, long)
-        and (AValue =:= something_else)
-    orelse
-        PredOne
-        andalso
-            something:very_long(based,
-                                on,
-                                PredOne,
-                                "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-        andalso AValue =:= something_other
-        andalso
-            something:potentially(
+    andalso something:potentially(
                 very:long(
-                    that:needs(indenting))).
+                    that:needs(indenting)))
+    orelse PredOne
+           and PredTwo
+           and something:potentially(very, extremely, long)
+           and (AValue =:= something_else)
+    orelse PredOne
+           andalso something:very_long(based,
+                                       on,
+                                       PredOne,
+                                       "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+           andalso AValue =:= something_other
+           andalso something:potentially(
+                       very:long(
+                           that:needs(indenting))).
 
 in_a_list(PredOne, PredTwo, AValue) ->
     [something:very_long(based,
@@ -36,25 +31,22 @@ in_a_list(PredOne, PredTwo, AValue) ->
                          "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
      andalso PredTwo
      andalso AValue =:= something
-     andalso
-         something:potentially(
-             very:long(
-                 that:needs(indenting))),
+     andalso something:potentially(
+                 very:long(
+                     that:needs(indenting))),
      PredOne
      and PredTwo
      and something:potentially(very, extremely, long)
      and (AValue =:= something_else),
      PredOne
-     andalso
-         something:very_long(based,
-                             on,
-                             PredOne,
-                             "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+     andalso something:very_long(based,
+                                 on,
+                                 PredOne,
+                                 "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
      andalso AValue =:= something_other
-     andalso
-         something:potentially(
-             very:long(
-                 that:needs(indenting)))].
+     andalso something:potentially(
+                 very:long(
+                     that:needs(indenting)))].
 
 precedence(One, Two, Three) ->
     careful:with(the,
@@ -72,24 +64,19 @@ other_operators(PredOne, PredTwo, AValue) ->
                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
     ++ PredTwo
     ++ AValue xor something
-    ++
-        something:potentially(
-            very:long(
-                that:needs(indenting)))
-        --
-            PredOne
-            + PredTwo
-            + something:potentially(very, extremely, long)
-            + AValue band something_else
-        --
-            PredOne
-            ++
-                something:very_long(based,
-                                    on,
-                                    PredOne,
-                                    "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-            ++ AValue band something_other
-            ++
-                something:potentially(
-                    very:long(
-                        that:needs(indenting))).
+    ++ something:potentially(
+           very:long(
+               that:needs(indenting)))
+       -- PredOne
+          + PredTwo
+          + something:potentially(very, extremely, long)
+          + AValue band something_else
+       -- PredOne
+          ++ something:very_long(based,
+                                 on,
+                                 PredOne,
+                                 "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+          ++ AValue band something_other
+          ++ something:potentially(
+                 very:long(
+                     that:needs(indenting))).

--- a/test_app/after/src/operator_indentation_with_parens.erl
+++ b/test_app/after/src/operator_indentation_with_parens.erl
@@ -7,58 +7,44 @@ a_large_predicate(PredOne, PredTwo, AValue) ->
                          on,
                          PredOne,
                          "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-     andalso
-         (PredTwo
-          andalso
-              ((AValue =:= something)
-               andalso
-                   something:potentially(
-                       very:long(
-                           that:needs(indenting))))))
-    orelse
-        ((((PredOne and PredTwo) and something:potentially(very, extremely, long))
-          and (AValue =:= something_else))
-         orelse
-             (PredOne
-              andalso
-                  (something:very_long(based,
-                                       on,
-                                       PredOne,
-                                       "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-                   andalso
-                       ((AValue =:= something_other)
-                        andalso
-                            something:potentially(
-                                very:long(
-                                    that:needs(indenting))))))).
+     andalso (PredTwo
+              andalso ((AValue =:= something)
+                       andalso something:potentially(
+                                   very:long(
+                                       that:needs(indenting))))))
+    orelse ((((PredOne and PredTwo) and something:potentially(very, extremely, long))
+             and (AValue =:= something_else))
+            orelse (PredOne
+                    andalso (something:very_long(based,
+                                                 on,
+                                                 PredOne,
+                                                 "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                             andalso ((AValue =:= something_other)
+                                      andalso something:potentially(
+                                                  very:long(
+                                                      that:needs(indenting))))))).
 
 in_a_list(PredOne, PredTwo, AValue) ->
     [something:very_long(based,
                          on,
                          PredOne,
                          "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-     andalso
-         (PredTwo
-          andalso
-              ((AValue =:= something)
-               andalso
-                   something:potentially(
-                       very:long(
-                           that:needs(indenting))))),
+     andalso (PredTwo
+              andalso ((AValue =:= something)
+                       andalso something:potentially(
+                                   very:long(
+                                       that:needs(indenting))))),
      ((PredOne and PredTwo) and something:potentially(very, extremely, long))
      and (AValue =:= something_else),
      PredOne
-     andalso
-         (something:very_long(based,
-                              on,
-                              PredOne,
-                              "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-          andalso
-              ((AValue =:= something_other)
-               andalso
-                   something:potentially(
-                       very:long(
-                           that:needs(indenting)))))].
+     andalso (something:very_long(based,
+                                  on,
+                                  PredOne,
+                                  "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+              andalso ((AValue =:= something_other)
+                       andalso something:potentially(
+                                   very:long(
+                                       that:needs(indenting)))))].
 
 precedence(One, Two, Three) ->
     careful:with(the,
@@ -74,27 +60,19 @@ other_operators(PredOne, PredTwo, AValue) ->
                         on,
                         PredOne,
                         "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-    ++
-        (PredTwo
-         ++
-             ((AValue xor something)
-              ++
-                  (something:potentially(
-                       very:long(
-                           that:needs(indenting)))
-                   --
-                       ((((PredOne + PredTwo) + something:potentially(very, extremely, long))
-                         + (AValue band something_else))
-                        --
-                            (PredOne
-                             ++
-                                 (something:very_long(based,
-                                                      on,
-                                                      PredOne,
-                                                      "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
-                                  ++
-                                      ((AValue band something_other)
-                                       ++
-                                           something:potentially(
-                                               very:long(
-                                                   that:needs(indenting)))))))))).
+    ++ (PredTwo
+        ++ ((AValue xor something)
+            ++ (something:potentially(
+                    very:long(
+                        that:needs(indenting)))
+                -- ((((PredOne + PredTwo) + something:potentially(very, extremely, long))
+                     + (AValue band something_else))
+                    -- (PredOne
+                        ++ (something:very_long(based,
+                                                on,
+                                                PredOne,
+                                                "1231231231231231313123123132sfsafsasfasdfasdfasdfsdf")
+                            ++ ((AValue band something_other)
+                                ++ something:potentially(
+                                       very:long(
+                                           that:needs(indenting)))))))))).


### PR DESCRIPTION
Fix #219 but, instead of not indenting _some_ operators… just don't indent after _any_ operator.
The code is more maintainable and the results will be consistent. I think this is better than what the ticket asks for.