### PR TITLE
[Fix #223] Don't let inline_simple_funs affect inline_clause_bodies

### DIFF
--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -366,12 +366,7 @@ lay_no_comments(Node, Ctxt) ->
                     % We force inlining here, to prevent fun() -> x end to use 3 lines
                     % if inline_simple_funs is true. Otherwise treat them as the rest
                     % of the code
-                    DClause =
-                        lay(Clause,
-                            Ctxt1#ctxt{inline_clause_bodies =
-                                           Ctxt1#ctxt.inline_simple_funs
-                                           orelse Ctxt1#ctxt.inline_clause_bodies,
-                                       clause = simple_fun_expr}),
+                    DClause = lay(Clause, Ctxt1#ctxt{clause = simple_fun_expr}),
                     sep([beside(text("fun"), DClause), text("end")]);
                 Clauses ->
                     lay_fun_sep(lay_clauses(Clauses, fun_expr, Ctxt1), Ctxt1)
@@ -1119,7 +1114,12 @@ make_simple_fun_clause(P, G, B, Ctxt) ->
 
     % Since this anonymous fun has a single clause, we don't need to indent its
     % body _that_ much
-    make_case_clause(D, G, B, Ctxt#ctxt{break_indent = 0}).
+    append_clause_body(B,
+                       append_guard(G, D, Ctxt),
+                       Ctxt#ctxt{inline_clause_bodies =
+                                     Ctxt#ctxt.inline_simple_funs
+                                     orelse Ctxt#ctxt.inline_clause_bodies,
+                                 break_indent = 0}).
 
 make_fun_clause(P, G, B, Ctxt) ->
     make_fun_clause(none, P, G, B, Ctxt).

--- a/src/rebar3_ast_formatter.erl
+++ b/src/rebar3_ast_formatter.erl
@@ -88,8 +88,10 @@ empty_lines(File) ->
     {Res, _} =
         lists:foldl(fun(Line, {EmptyLines, N}) ->
                        case re:run(Line, NonEmptyLineRe) of
-                           {match, _} -> {EmptyLines, N + 1};
-                           nomatch -> {[N | EmptyLines], N + 1}
+                           {match, _} ->
+                               {EmptyLines, N + 1};
+                           nomatch ->
+                               {[N | EmptyLines], N + 1}
                        end
                     end,
                     {[], 1},

--- a/test_app/after/src/inline_clause_bodies.erl
+++ b/test_app/after/src/inline_clause_bodies.erl
@@ -116,3 +116,13 @@ try_expr(Inline) ->
              rebar3,
              formatter]
     end.
+
+simple_fun_expr() ->
+    fun() ->
+       case with:some() of
+           clauses ->
+               that:should();
+           be ->
+               indented
+       end
+    end.

--- a/test_app/after/src/no_inline_funs.erl
+++ b/test_app/after/src/no_inline_funs.erl
@@ -55,3 +55,13 @@ long() ->
        {IncrediblyLongFunctionName(IncrediblyLongVariableName),
         IncrediblyLongFunctionName(IncrediblyLongVariableName)}
     end.
+
+clauses() ->
+    fun() ->
+       case with:some() of
+           clauses ->
+               that:should();
+           be ->
+               indented
+       end
+    end.

--- a/test_app/src/inline_clause_bodies.erl
+++ b/test_app/src/inline_clause_bodies.erl
@@ -68,3 +68,12 @@ try_expr(Inline) ->
            rebar3, formatter]
     end.
 
+simple_fun_expr() ->
+    fun() ->
+        case with:some() of
+            clauses ->
+                that:should();
+            be ->
+                indented
+        end
+    end.

--- a/test_app/src/no_inline_funs.erl
+++ b/test_app/src/no_inline_funs.erl
@@ -24,3 +24,13 @@ long() ->
     fun(IncrediblyLongVariableName) ->
            {IncrediblyLongFunctionName(IncrediblyLongVariableName),
             IncrediblyLongFunctionName(IncrediblyLongVariableName)} end.
+
+clauses() ->
+    fun() ->
+        case with:some() of
+            clauses ->
+                that:should();
+            be ->
+                indented
+        end
+    end.


### PR DESCRIPTION
[Fix #223] Don't let inline_simple_funs affect inline_clause_bodies