### PR TITLE
Fix #227: Don't put parentheses around 'ignore'

### DIFF
--- a/test_app/after/src/attrs.erl
+++ b/test_app/after/src/attrs.erl
@@ -1,0 +1,19 @@
+-module(should_be_in_parentheses).
+
+-export([should/1, have_parentheses/0]).
+
+-hank ignore.
+
+-elvis ignore.
+
+-format #{should_not => have_parentheses}.
+
+-type should() :: {'not', have, parentheses}.
+
+-this({attribute, should, have, parentheses}).
+
+-this_one_the_formater_should ignore.
+
+-spec should(Not) -> have:parentheses().
+should(Not) ->
+    have:parentheses().

--- a/test_app/src/attrs.erl
+++ b/test_app/src/attrs.erl
@@ -1,0 +1,11 @@
+-module should_be_in_parentheses.
+-export([should/1, have_parentheses/0]).
+-hank ignore.
+-elvis ignore.
+-format #{should_not => have_parentheses}.
+-type should() :: {'not', have, parentheses}.
+-this({attribute, should, have, parentheses}).
+-this_one_the_formater_should ignore.
+
+-spec should(Not) -> have:parentheses().
+should(Not) -> have:parentheses().


### PR DESCRIPTION
Fix #227: Don't put parentheses around `ignore`.