### PR TITLE
Add rebar.config for tests

### DIFF
--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -11,7 +11,7 @@ test_app(_Config) ->
         rebar3_format:init(
             rebar_state:new()),
     Files =
-        {files, ["src/*.app.src", "src/*.sh", "src/*.erl", "src/*/*.erl", "include/*.hrl"]},
+        {files, ["*.config", "src/*.app.src", "src/*.sh", "src/*.erl", "src/*/*.erl", "include/*.hrl"]},
     IgnoredFiles =
         case string:to_integer(
                  erlang:system_info(otp_release))

--- a/test_app/after/rebar.config
+++ b/test_app/after/rebar.config
@@ -1,0 +1,23 @@
+{erl_opts,
+ [warn_unused_vars,
+  warn_export_all,
+  warn_shadow_vars,
+  warn_unused_import,
+  warn_unused_function,
+  warn_bif_clash,
+  warn_unused_record,
+  warn_deprecated_function,
+  warn_obsolete_guard,
+  strict_validation,
+  warn_export_vars,
+  warn_exported_vars,
+  debug_info]}.
+
+{deps, []}.
+
+{project_plugins, [rebar3_format]}.
+
+{format,
+ [{files, ["src/*.erl", "src/*/*.erl", "include/*.hrl"]},
+  {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]},
+  {options, #{dummy => option}}]}.


### PR DESCRIPTION
Related to issue https://github.com/AdRoll/rebar3_format/issues/251.
The main logic for default formatting was added in the scope https://github.com/AdRoll/rebar3_format/pull/230. The latest version of plugin do formatting as well for `*.config` files in the root folder by default. But at the same time was miss in test cases.