### PR TITLE
[WIP] Fixes #81: add parentheses to macros inside of binaries

### DIFF
--- a/test_app/after/src/macros_in_binary.erl
+++ b/test_app/after/src/macros_in_binary.erl
@@ -1,0 +1,16 @@
+-module(macros_in_binary).
+
+-export([chunkify/1, p/0]).
+
+-define(CHUNK_SIZE, 65535 - 1).
+-define(CONCAT(A, B), <<A/binary, B/binary>>).
+-define(A_MACRO(X), X + 1).
+
+chunkify(<<Binary:(?CHUNK_SIZE)/binary, Rest/binary>>) ->
+    {<<(?CONCAT(Binary, Rest))/binary>>, <<(?CONCAT(Binary, Rest))/binary>>}.
+
+p() ->
+    <<begin
+          X = rand:uniform(10),
+          X + (?A_MACRO(X))
+      end/integer>>.

--- a/test_app/src/macros_in_binary.erl
+++ b/test_app/src/macros_in_binary.erl
@@ -1,0 +1,17 @@
+-module(macros_in_binary).
+
+-export([chunkify/1, p/0]).
+
+-define(CHUNK_SIZE, 65535 - 1).
+-define(CONCAT(A, B), <<A/binary, B/binary>>).
+-define(A_MACRO(X), X + 1).
+
+chunkify(<<Binary:(?CHUNK_SIZE)/binary, Rest/binary>>) ->
+    {<<(?CONCAT(Binary, Rest))/binary>>, <<?CONCAT(Binary, Rest)/binary>>}.
+
+p() ->
+    <<begin
+          X = rand:uniform(10),
+          X + ?A_MACRO(X)
+      end/integer>>.
+


### PR DESCRIPTION
# WORK IN PROGRESS

Related to https://github.com/AdRoll/rebar3_format/issues/81. A little bit dirty but working solution.