### PR TITLE
Added app discovery to rebar3 format provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then just call your plugin directly in an existing application:
 
     $ rebar3 format
 
-This will format every Erlang file (including `hrl`s, `erl`s and `app.src`s) under `src`, `include` and `test` by default, together with every `.config` file in your root directory. You can specify the directory/file to format as following:
+By default, this will format every Erlang file (including `hrl`s, `erl`s and `app.src`s) under `src`, `include` and `test`, together with every `.config` file, in your root directory and any nested Erlang apps' directories within your project. You can specify the directory/file to format as following:
 
     $ rebar3 format --files 'src/my_subdir/*.erl'
     $ rebar3 format --files src/other_subdir/my_file.erl

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -87,30 +87,31 @@ get_action(Args) ->
                    [file:filename_all()].
 get_files(Args, State, Dirs) ->
     FilesFromArgs = [Value || {files, Value} <- Args],
-    Patterns =
+    {Patterns, Dirs1} =
         case FilesFromArgs of
             [] ->
                 FormatConfig = rebar_state:get(State, format, []),
                 case proplists:get_value(files, FormatConfig, undefined) of
                     undefined ->
-                        ["include/**/*.[he]rl",
-                         "include/**/*.app.src",
-                         "src/**/*.[he]rl",
-                         "src/**/*.app.src",
-                         "test/**/*.[he]rl",
-                         "test/**/*.app.src",
-                         "{rebar,elvis,sys}.config"];
+                        {["include/**/*.[he]rl",
+                          "include/**/*.app.src",
+                          "src/**/*.[he]rl",
+                          "src/**/*.app.src",
+                          "test/**/*.[he]rl",
+                          "test/**/*.app.src",
+                          "{rebar,elvis,sys}.config"],
+                         Dirs};
                     Wildcards ->
-                        Wildcards
+                        {Wildcards, [""]}
                 end;
             Files ->
-                Files
+                {Files, [""]}
         end,
     %% Special handling needed for "" (current directory)
     %% so that ignore-lists work in an expected way.
-    [File || lists:member("", Dirs), Pattern <- Patterns, File <- filelib:wildcard(Pattern)]
+    [File || lists:member("", Dirs1), Pattern <- Patterns, File <- filelib:wildcard(Pattern)]
     ++ [filename:join(Dir, File)
-        || Dir <- Dirs, Dir =/= "", Pattern <- Patterns, File <- filelib:wildcard(Pattern, Dir)].
+        || Dir <- Dirs1, Dir =/= "", Pattern <- Patterns, File <- filelib:wildcard(Pattern, Dir)].
 
 -spec get_ignored_files(rebar_state:t()) -> [file:filename_all()].
 get_ignored_files(State) ->

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -100,16 +100,16 @@ get_files(Args, State, Dirs) ->
                           "test/**/*.[he]rl",
                           "test/**/*.app.src",
                           "{rebar,elvis,sys}.config"],
-                         lists:usort(["" | Dirs])};
+                         Dirs};
                     Wildcards ->
-                        {Wildcards, [""]}
+                        {Wildcards, []}
                 end;
             Files ->
-                {Files, [""]}
+                {Files, []}
         end,
     %% Special handling needed for "" (current directory)
     %% so that ignore-lists work in an expected way.
-    [File || lists:member("", Dirs1), Pattern <- Patterns, File <- filelib:wildcard(Pattern)]
+    [File || Pattern <- Patterns, File <- filelib:wildcard(Pattern)]
     ++ [filename:join(Dir, File)
         || Dir <- Dirs1, Dir =/= "", Pattern <- Patterns, File <- filelib:wildcard(Pattern, Dir)].
 

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -100,7 +100,7 @@ get_files(Args, State, Dirs) ->
                           "test/**/*.[he]rl",
                           "test/**/*.app.src",
                           "{rebar,elvis,sys}.config"],
-                         Dirs};
+                         lists:usort(["" | Dirs])};
                     Wildcards ->
                         {Wildcards, [""]}
                 end;

--- a/src/rebar3_format_prv.erl
+++ b/src/rebar3_format_prv.erl
@@ -32,13 +32,22 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, iodata()}.
 do(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
+    Apps =
+        case rebar_state:current_app(State) of
+            undefined ->
+                rebar_state:project_apps(State);
+            AppInfo ->
+                [AppInfo]
+        end,
+    Cwd = rebar_state:dir(State),
+    Dirs = [dir_for_app(AppInfo, Cwd) || AppInfo <- Apps],
     Action = get_action(Args),
     OutputDirOpt = get_output_dir(Action, Args),
     Opts = maps:put(action, Action, maps:put(output_dir, OutputDirOpt, get_opts(State))),
     rebar_api:debug("Formatter options: ~p", [Opts]),
     Formatter = get_formatter(State, Opts),
     IgnoredFiles = get_ignored_files(State),
-    Files = get_files(Args, State) -- IgnoredFiles,
+    Files = get_files(Args, State, Dirs) -- IgnoredFiles,
     rebar_api:debug("Found ~p files: ~p", [length(Files), Files]),
     case format_files(Files, Formatter) of
         ok ->
@@ -47,6 +56,14 @@ do(State) ->
         {error, Error} ->
             {error, format_error(Error)}
     end.
+
+%% @private
+-spec dir_for_app(rebar_app_info:t(), file:filename_all()) -> file:filename_all() | [].
+dir_for_app(AppInfo, Cwd) ->
+    {ok, Dir} =
+        rebar_file_utils:path_from_ancestor(
+            rebar_app_info:dir(AppInfo), Cwd),
+    Dir.
 
 %% @private
 -spec format_error(any()) -> string().
@@ -66,8 +83,9 @@ get_action(Args) ->
             format
     end.
 
--spec get_files(proplists:proplist(), rebar_state:t()) -> [file:filename_all()].
-get_files(Args, State) ->
+-spec get_files(proplists:proplist(), rebar_state:t(), [file:filename_all() | []]) ->
+                   [file:filename_all()].
+get_files(Args, State, Dirs) ->
     FilesFromArgs = [Value || {files, Value} <- Args],
     Patterns =
         case FilesFromArgs of
@@ -88,7 +106,11 @@ get_files(Args, State) ->
             Files ->
                 Files
         end,
-    [File || Pattern <- Patterns, File <- filelib:wildcard(Pattern)].
+    %% Special handling needed for "" (current directory)
+    %% so that ignore-lists work in an expected way.
+    [File || lists:member("", Dirs), Pattern <- Patterns, File <- filelib:wildcard(Pattern)]
+    ++ [filename:join(Dir, File)
+        || Dir <- Dirs, Dir =/= "", Pattern <- Patterns, File <- filelib:wildcard(Pattern, Dir)].
 
 -spec get_ignored_files(rebar_state:t()) -> [file:filename_all()].
 get_ignored_files(State) ->

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -150,7 +150,8 @@ init(Opts) ->
     {ok, State1} =
         rebar3_format:init(
             rebar_state:new()),
+    {ok, State2} = rebar3_prv_app_discovery:do(State1),
     Files = {files, ["src/minimal.erl"]},
     Formatter = {formatter, erlfmt_formatter},
     Out = {options, Opts},
-    rebar_state:set(State1, format, [Files, Formatter, Out]).
+    rebar_state:set(State2, format, [Files, Formatter, Out]).

--- a/test/erlfmt_formatter_SUITE.erl
+++ b/test/erlfmt_formatter_SUITE.erl
@@ -150,7 +150,7 @@ init(Opts) ->
     {ok, State1} =
         rebar3_format:init(
             rebar_state:new()),
-    {ok, State2} = rebar3_prv_app_discovery:do(State1),
+    {ok, State2} = rebar_prv_app_discovery:do(State1),
     Files = {files, ["src/minimal.erl"]},
     Formatter = {formatter, erlfmt_formatter},
     Out = {options, Opts},

--- a/test/otp_formatter_SUITE.erl
+++ b/test/otp_formatter_SUITE.erl
@@ -9,9 +9,7 @@ all() ->
 
 test_app(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
-    {ok, State1} =
-        rebar3_format:init(
-            rebar_state:new()),
+    {ok, State1} = init(),
     Files =
         {files, ["src/*.app.src", "src/*.sh", "src/*.erl", "src/*/*.erl", "include/*.hrl"]},
     Formatter = {formatter, otp_formatter},
@@ -45,9 +43,7 @@ test_app(_Config) ->
 
 error(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
-    {ok, State1} =
-        rebar3_format:init(
-            rebar_state:new()),
+    {ok, State1} = init(),
     Formatter = {formatter, otp_formatter},
     State2 = rebar_state:set(State1, format, [Formatter]),
     %% OTP formatter can't parse some of our files in test_app/src because of macros
@@ -56,9 +52,7 @@ error(_Config) ->
 %% otp_formatter messes up with some files. We have a mechanism to catch that.
 modified_ast(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
-    {ok, State1} =
-        rebar3_format:init(
-            rebar_state:new()),
+    {ok, State1} = init(),
     Files = {files, ["src/dodge_macros.erl"]},
     Formatter = {formatter, otp_formatter},
     State2 = rebar_state:set(State1, format, [Files, Formatter]),
@@ -72,3 +66,9 @@ verify(State) ->
 format(State) ->
     rebar3_format_prv:do(
         rebar_state:command_parsed_args(State, {[{output, "formatted_as_otp"}], something})).
+
+init() ->
+    {ok, State} =
+        rebar_prv_app_discovery:do(
+            rebar_state:new()),
+    rebar3_format:init(State).

--- a/test/sr_formatter_SUITE.erl
+++ b/test/sr_formatter_SUITE.erl
@@ -77,9 +77,10 @@ init(Options) ->
         file:set_cwd(
             filename:join(
                 code:priv_dir(rebar3_format), "../test_app")),
-    {ok, State1} =
-        rebar3_format:init(
+    {ok, State0} =
+        rebar_prv_app_discovery:do(
             rebar_state:new()),
+    {ok, State1} = rebar3_format:init(State0),
     Files = {files, ["src/brackets.erl"]},
     Formatter = {formatter, sr_formatter},
     Opts = {options, Options},

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -9,35 +9,19 @@ all() ->
 
 test_app(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
-    {ok, State1} =
-        rebar3_format:init(
-            rebar_state:new()),
-    Files =
-        {files,
-         ["*.config", "src/*.app.src", "src/*.sh", "src/*.erl", "src/*/*.erl", "include/*.hrl"]},
-    IgnoredFiles =
-        case string:to_integer(
-                 erlang:system_info(otp_release))
-        of
-            {N, []} when N >= 23 ->
-                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
-            _ ->
-                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp23.erl"]}
-        end,
-    State2 = rebar_state:set(State1, format, [Files, IgnoredFiles]),
+    State2 = init_test_app(),
     {error, _} = verify(State2),
     {ok, _} = format(State2),
     {error, _} = verify(State2),
     ok = file:set_cwd("formatted"),
-    {ok, _} = verify(State2),
+    State3 = init_test_app(),
+    {ok, _} = verify(State3),
     ok = file:set_cwd(".."),
     ok = git_diff().
 
 no_good_files(_Config) ->
     ok = file:set_cwd("../../../../test_app"),
-    {ok, State1} =
-        rebar3_format:init(
-            rebar_state:new()),
+    {ok, State1} = init(),
     Files = {files, ["a.broken.file", "a.non.existent.file"]},
     State2 = rebar_state:set(State1, format, [Files]),
     %% Our parsers don't crash on unparseable or non-existent files
@@ -50,6 +34,28 @@ verify(State) ->
 format(State) ->
     rebar3_format_prv:do(
         rebar_state:command_parsed_args(State, {[{output, "formatted"}], something})).
+
+init() ->
+    {ok, State} =
+        rebar_prv_app_discovery:do(
+            rebar_state:new()),
+    rebar3_format:init(State).
+
+init_test_app() ->
+    {ok, State1} = init(),
+    Files =
+        {files,
+         ["*.config", "src/*.app.src", "src/*.sh", "src/*.erl", "src/*/*.erl", "include/*.hrl"]},
+    IgnoredFiles =
+        case string:to_integer(
+                 erlang:system_info(otp_release))
+        of
+            {N, []} when N >= 23 ->
+                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
+            _ ->
+                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp23.erl"]}
+        end,
+    rebar_state:set(State1, format, [Files, IgnoredFiles]).
 
 git_diff() ->
     case os:cmd("git --no-pager diff --no-index -- after formatted") of


### PR DESCRIPTION
Default wildcards are now applied to all app directories,
and special care is taken so that behaviour is the same if the app
directory is the root directory.

Unfortunately, had to modify quite a lot of tests - first, to invoke app
discovery (as specified by the provider); second, test_app test changed
the working directory without re-updating the state, and that obviously
didn't work out great.

------

Let me know if you'd like some touch-ups - my priorities were "make it work" and "adjust the tests so that there are no false negatives". This definitely resulted in some less-than-ideal code.