### PR TITLE
[#280] Fix #280: Handle space-terminated strings

### DIFF
--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -1099,7 +1099,7 @@ lay_string_line(S, _) ->
 
 %% @doc We need to replace \n\t here as a work around for how remove_tabs/1 works
 %%      It's a hack, but it makes the formatter consistent.
-%%      And it only affect strings that start with tab right after a newline.
+%%      And it only affects strings that start with tab right after a newline.
 %%      We truly hope that there are not too many of those.
 %%      We also need to convert the rightmost space to \s to prevent
 %%      remove_trailing_spaces/1 from removing it. Again another workaround.

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -1095,11 +1095,19 @@ lay_string_line(S, #ctxt{truncate_strings = true, ribbon = Ribbon}) ->
     %% width is 2/3 of the ribbon width - this seems to work well.
     lay_string(S, length(S), Ribbon * 2 div 3);
 lay_string_line(S, _) ->
-    %% We need to replace \n\t here as a work around for how remove_tabs/1 works
-    %% It's a hack, but it makes the formatter consistent.
-    %% And it only affect strings that start with tab right after a newline.
-    %% We truly hope that there are not too many of those.
-    text(switch_tabs_after_newline(S)).
+    text(prepare_string_line(S)).
+
+%% @doc We need to replace \n\t here as a work around for how remove_tabs/1 works
+%%      It's a hack, but it makes the formatter consistent.
+%%      And it only affect strings that start with tab right after a newline.
+%%      We truly hope that there are not too many of those.
+%%      We also need to convert the rightmost space to \s to prevent
+%%      remove_trailing_spaces/1 from removing it. Again another workaround.
+prepare_string_line(S) ->
+    switch_tabs_after_newline(switch_trailing_spaces(S)).
+
+switch_trailing_spaces(String) ->
+    re:replace(String, "\s\n", "\\\\s\n", [global, {return, list}, unicode]).
 
 switch_tabs_after_newline(String) ->
     case re:replace(String,

--- a/test_app/after/src/strings/strings.erl
+++ b/test_app/after/src/strings/strings.erl
@@ -7,7 +7,7 @@
 -attr({with, "a string"}).
 
 all() ->
-    heredoc(), superlong(), repeat(), multiple_calls(), characters().
+    heredoc(), superlong(), repeat(), multiple_calls(), characters(), multiline_with_spaces().
 
 superlong() ->
     "This is a super super super super super super super super super super super super super super super super super super super super super super super super super super super super super long string!"
@@ -60,3 +60,8 @@ multiple_calls_more() ->
 characters() ->
     {"\x63haracters with strange representations are preserved" ++ " in small strings",
      "\x65v\x65n in multiblock strings"}.
+
+multiline_with_spaces() ->
+    "This is a multiline string and this line ends with two spaces \s
+     and this one ends with two tabs		
+    The spaces should not be removed by the formatter.".

--- a/test_app/src/strings/strings.erl
+++ b/test_app/src/strings/strings.erl
@@ -11,7 +11,8 @@ all() ->
   superlong(),
   repeat(),
   multiple_calls(),
-  characters().
+  characters(),
+  multiline_with_spaces().
 
 
 superlong() ->
@@ -60,3 +61,8 @@ characters() ->
     ++ " in small strings",
     "\x65v\x65n in multiblock strings"
     }.
+
+multiline_with_spaces() ->
+    "This is a multiline string and this line ends with two spaces  
+     and this one ends with two tabs		
+    The spaces should not be removed by the formatter.".


### PR DESCRIPTION
Fix #280.
Actually, it's sort of a _workaround_ to preserve the semantic value of the string while still being able to trim trailing whitespace from files easily.
I think it's a good tradeoff since, just like not too many people start their multiline strings with tabs, not too many people should finish them with spaces.