### PR TITLE
Notify escript not supported

### DIFF
--- a/src/rebar3_format.erl
+++ b/src/rebar3_format.erl
@@ -1,9 +1,9 @@
 %%% @doc Main entry point for the rebar3 format plugin
 -module(rebar3_format).
 
--elvis({elvis_style, no_call, disable}).
+-elvis([{elvis_style, no_debug_call, disable}]).
 
--hank({unnecessary_function_argument, [{main, 1, 1}]}).
+-hank([{unnecessary_function_arguments, [{main, 1, 1}]}]).
 
 -export([init/1, main/1]).
 

--- a/src/rebar3_format.erl
+++ b/src/rebar3_format.erl
@@ -1,9 +1,14 @@
 %%% @doc Main entry point for the rebar3 format plugin
 -module(rebar3_format).
 
--export([init/1]).
+-export([init/1, main/1]).
 
 %% @private
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     rebar3_format_prv:init(State).
+
+%% @private
+-spec main(any()) -> no_return().
+main(_) ->
+    rebar_api:abort("rebar3_format shall be run as a plugin, not as an escript.", []).

--- a/src/rebar3_format.erl
+++ b/src/rebar3_format.erl
@@ -17,7 +17,5 @@ init(State) ->
 main(_) ->
     Msg = "rebar3_format shall be run as a plugin, not as an escript.~n",
 
-    % Not possible (no other module found in an escript context):
-    %rebar_api:abort(Msg, []).
     io:format(Msg),
     exit(escript_not_supported).

--- a/src/rebar3_format.erl
+++ b/src/rebar3_format.erl
@@ -1,6 +1,10 @@
 %%% @doc Main entry point for the rebar3 format plugin
 -module(rebar3_format).
 
+-elvis({elvis_style, no_call, disable}).
+
+-hank({unnecessary_function_argument, [{main, 1, 1}]}).
+
 -export([init/1, main/1]).
 
 %% @private
@@ -11,4 +15,9 @@ init(State) ->
 %% @private
 -spec main(any()) -> no_return().
 main(_) ->
-    rebar_api:abort("rebar3_format shall be run as a plugin, not as an escript.", []).
+    Msg = "rebar3_format shall be run as a plugin, not as an escript.~n",
+
+    % Not possible (no other module found in an escript context):
+    %rebar_api:abort(Msg, []).
+    io:format(Msg),
+    exit(escript_not_supported).

--- a/test.dict
+++ b/test.dict
@@ -14,3 +14,4 @@ modified_ast
 o_o
 otp_formatter
 test_app
+rebar3_format


### PR DESCRIPTION
Notifying that rebar_format must be run as a plugin, not as an escript.