### PR TITLE
[fix-sort_arity_qualifiers] Add a minimal module that proves that sort_arity_qualifiers crashes for export_type qualifiers

### DIFF
--- a/test_app/after/src/sort_arity_qualifiers/sort_arity_qualifiers_minimal_export_type.erl
+++ b/test_app/after/src/sort_arity_qualifiers/sort_arity_qualifiers_minimal_export_type.erl
@@ -1,0 +1,8 @@
+-module(sort_arity_qualifiers_minimal_export_type).
+
+-format #{sort_arity_qualifiers => true}.
+
+-type wololo() :: ok.
+-type ninjalui() :: ok.
+
+-export_type([ninjalui/0, wololo/0]).

--- a/test_app/src/sort_arity_qualifiers/sort_arity_qualifiers_minimal_export_type.erl
+++ b/test_app/src/sort_arity_qualifiers/sort_arity_qualifiers_minimal_export_type.erl
@@ -1,0 +1,8 @@
+-module(sort_arity_qualifiers_minimal_export_type).
+
+-format #{sort_arity_qualifiers => true}.
+
+-type wololo() :: ok.
+-type ninjalui() :: ok.
+
+-export_type([wololo/0, ninjalui/0]).


### PR DESCRIPTION
Fixes #349.

(yes, I woke up wanting to write some Age of Empires 2 references)