### PR TITLE
Update formatters with changes from OTP 26

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['25']
+        otp: ['26']
         rebar: ['3.24']
 
     steps:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -17,19 +17,19 @@ jobs:
         rebar: ['3.24']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: erlef/setup-beam@v1
       id: setup-beam
       with:
         otp-version: ${{matrix.otp}}
         rebar3-version: ${{matrix.rebar}}
     - name: Restore _build
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: _build
         key: _build-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
     - name: Restore rebar3's cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3
         key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['26']
+        otp: ['25', '26']
         rebar: ['3.24']
 
     steps:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,8 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['24.3', '25.2.1']
-        rebar: ['3.20.0']
+        otp: ['25']
+        rebar: ['3.24']
 
     steps:
     - uses: actions/checkout@v2

--- a/nextroll.dict
+++ b/nextroll.dict
@@ -35,6 +35,8 @@ lay_clauses
 lay_items
 old-reliable
 otp25
+otp26
+otp27
 paragraph-format
 per-file
 plugin

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,8 @@
   {rebar3_sheldon, "~> 0.4.3"},
   {rebar3_ex_doc, "~> 0.2.23"}]}.
 
-{dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
+{dialyzer,
+ [{warnings, [no_unknown, no_return, unmatched_returns, error_handling, underspecs]}]}.
 
 {edoc_opts, [{todo, true}, {overview, "priv/overview.edoc"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -18,8 +18,7 @@
   {rebar3_sheldon, "~> 0.4.3"},
   {rebar3_ex_doc, "~> 0.2.23"}]}.
 
-{dialyzer,
- [{warnings, [no_unknown, no_return, unmatched_returns, error_handling, underspecs]}]}.
+{dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
 
 {edoc_opts, [{todo, true}, {overview, "priv/overview.edoc"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,8 @@
   {rebar3_sheldon, "~> 0.4.3"},
   {rebar3_ex_doc, "~> 0.2.24"}]}.
 
-{dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
+{dialyzer,
+ [{warnings, [no_unknown, no_return, unmatched_returns, error_handling, underspecs]}]}.
 
 {edoc_opts, [{todo, true}, {overview, "priv/overview.edoc"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [warn_unused_import, warn_export_vars, verbose, report, debug_info]}.
 
-{minimum_otp_vsn, "24"}.
+{minimum_otp_vsn, "25"}.
 
 {deps, [{katana_code, "~> 2.2.0"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {minimum_otp_vsn, "24"}.
 
-{deps, [{katana_code, "~> 2.1.0"}]}.
+{deps, [{katana_code, "~> 2.2.0"}]}.
 
 {ex_doc,
  [{source_url, <<"https://github.com/AdRoll/rebar3_format">>},
@@ -13,10 +13,10 @@
 
 {project_plugins,
  [{rebar3_hex, "~> 7.0.8"},
-  {rebar3_hank, "~> 1.4.0"},
-  {rebar3_lint, "~> 3.2.5"},
+  {rebar3_hank, "~> 1.4.1"},
+  {rebar3_lint, "~> 3.2.6"},
   {rebar3_sheldon, "~> 0.4.3"},
-  {rebar3_ex_doc, "~> 0.2.23"}]}.
+  {rebar3_ex_doc, "~> 0.2.24"}]}.
 
 {dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
-[{<<"katana_code">>,{pkg,<<"katana_code">>,<<"2.1.0">>},0}]}.
+[{<<"katana_code">>,{pkg,<<"katana_code">>,<<"2.2.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"katana_code">>, <<"0C42BDCD7E59995876AED9F678CF62E3D12EF42E0FBB2190556E64BFEBDD15C6">>}]},
+ {<<"katana_code">>, <<"B67EAA70022702AFEC2803E33C89ABE3D817197E7A16246614FED42E03AA8753">>}]},
 {pkg_hash_ext,[
- {<<"katana_code">>, <<"AE3BBACA187511588F69695A9FF22251CB2CC672FDCCC180289779BDD25175EF">>}]}
+ {<<"katana_code">>, <<"A01F9FDBA838478FDFDE183A324FA12ECE9BA127935065395D01427FC5110CBB">>}]}
 ].

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -594,23 +594,17 @@ lay_no_comments(Node, Ctxt) ->
             Ctxt1 = reset_prec(Ctxt),
             D1 = lay(erl_syntax:generator_pattern(Node), Ctxt1),
             D2 = lay(erl_syntax:generator_body(Node), Ctxt1),
-            prettypr:par([D1,
-                          prettypr:beside(
-                              prettypr:text("<- "), D2)],
-                         Ctxt1#ctxt.break_indent);
+            lay_generator(D1, D2, "<- ", Ctxt1);
         binary_generator ->
             Ctxt1 = reset_prec(Ctxt),
             D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
             D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
-            prettypr:par([D1,
-                          prettypr:beside(
-                              prettypr:text("<= "), D2)],
-                         Ctxt1#ctxt.break_indent);
+            lay_generator(D1, D2, "<= ", Ctxt1);
         map_generator ->
             Ctxt1 = reset_prec(Ctxt),
             D1 = lay(erl_syntax:map_generator_pattern(Node), Ctxt1),
             D2 = lay(erl_syntax:map_generator_body(Node), Ctxt1),
-            prettypr:par([D1, prettypr:beside(prettypr:text("<- "), D2)], Ctxt1#ctxt.break_indent);
+            lay_generator(D1, D2, "<- ", Ctxt1);
         implicit_fun ->
             D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
             prettypr:beside(lay_text_float("fun "), D);
@@ -631,7 +625,7 @@ lay_no_comments(Node, Ctxt) ->
             D1 = lay(erl_syntax:map_comp_template(Node), Ctxt1),
             D2 = lay_items(erl_syntax:map_comp_body(Node), Ctxt1, fun lay/2),
             D3 = prettypr:beside(lay_text_float("|| "), prettypr:beside(D2, lay_text_float("}"))),
-            prettypr:beside(lay_text_float("#{"),prettypr:par([D1, D3]));
+            prettypr:beside(lay_text_float("#{"), prettypr:par([D1, D3]));
         macro ->
             %% This is formatted similar to a normal function call or a variable
             N = macro_name(Node, variable),
@@ -1094,6 +1088,12 @@ maybe_convert_to_qualifier(Node, #ctxt{force_arity_qualifiers = true}) ->
         _ ->
             Node
     end.
+
+lay_generator(D1, D2, Connector, Ctxt) ->
+    prettypr:par([D1,
+                  prettypr:beside(
+                      prettypr:text(Connector), D2)],
+                 Ctxt#ctxt.break_indent).
 
 lay_nested_infix_expr(Node, #ctxt{parenthesize_infix_operations = false} = Ctxt) ->
     lay(Node, Ctxt);

--- a/src/formatters/default_formatter.erl
+++ b/src/formatters/default_formatter.erl
@@ -606,6 +606,11 @@ lay_no_comments(Node, Ctxt) ->
                           prettypr:beside(
                               prettypr:text("<= "), D2)],
                          Ctxt1#ctxt.break_indent);
+        map_generator ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:map_generator_pattern(Node), Ctxt1),
+            D2 = lay(erl_syntax:map_generator_body(Node), Ctxt1),
+            prettypr:par([D1, prettypr:beside(prettypr:text("<- "), D2)], Ctxt1#ctxt.break_indent);
         implicit_fun ->
             D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
             prettypr:beside(lay_text_float("fun "), D);
@@ -621,6 +626,12 @@ lay_no_comments(Node, Ctxt) ->
             D2 = lay_items(erl_syntax:binary_comp_body(Node), Ctxt1, fun lay/2),
             D3 = prettypr:beside(lay_text_float("|| "), prettypr:beside(D2, lay_text_float(" >>"))),
             prettypr:beside(lay_text_float("<< "), prettypr:par([D1, D3]));
+        map_comp ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:map_comp_template(Node), Ctxt1),
+            D2 = lay_items(erl_syntax:map_comp_body(Node), Ctxt1, fun lay/2),
+            D3 = prettypr:beside(lay_text_float("|| "), prettypr:beside(D2, lay_text_float("}"))),
+            prettypr:beside(lay_text_float("#{"),prettypr:par([D1, D3]));
         macro ->
             %% This is formatted similar to a normal function call or a variable
             N = macro_name(Node, variable),

--- a/src/formatters/otp_formatter.erl
+++ b/src/formatters/otp_formatter.erl
@@ -664,6 +664,11 @@ lay_no_comments(Node, Ctxt) ->
             D1 = lay(erl_syntax:binary_generator_pattern(Node), Ctxt1),
             D2 = lay(erl_syntax:binary_generator_body(Node), Ctxt1),
             par([D1, beside(text("<= "), D2)], Ctxt1#ctxt.break_indent);
+        map_generator ->
+            Ctxt1 = reset_prec(Ctxt),
+            D1 = lay(erl_syntax:map_generator_pattern(Node), Ctxt1),
+            D2 = lay(erl_syntax:map_generator_body(Node), Ctxt1),
+            par([D1, beside(text("<- "), D2)], Ctxt1#ctxt.break_indent);
         implicit_fun ->
             D = lay(erl_syntax:implicit_fun_name(Node), reset_prec(Ctxt)),
             beside(lay_text_float("fun "), D);
@@ -679,6 +684,12 @@ lay_no_comments(Node, Ctxt) ->
             D2 = par(seq(erl_syntax:binary_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
             beside(lay_text_float("<< "),
                    par([D1, beside(lay_text_float(" || "), beside(D2, lay_text_float(" >>")))]));
+        map_comp ->
+            Ctxt1 = set_prec(Ctxt, max_prec()),
+            D1 = lay(erl_syntax:map_comp_template(Node), Ctxt1),
+            D2 = par(seq(erl_syntax:map_comp_body(Node), lay_text_float(","), Ctxt1, fun lay/2)),
+            beside(lay_text_float("#{"),
+                   par([D1, beside(lay_text_float("|| "), beside(D2, lay_text_float("}")))]));
         macro ->
             %% This is formatted similar to a normal function call, but
             %% prefixed with a "?".

--- a/test/otp_formatter_SUITE.erl
+++ b/test/otp_formatter_SUITE.erl
@@ -17,7 +17,16 @@ test_app(_Config) ->
         case string:to_integer(
                  erlang:system_info(otp_release))
         of
-            {N, _} when N >= 25 ->
+            {N, _} when N >= 26 ->
+                {ignore,
+                 ["src/strings/non_heredoc.erl", %% newlines in strings are treated differently since OTP26
+                  "src/*_ignore.erl",
+                  "src/comments.erl",
+                  "src/ignored_file_config.erl",
+                  "src/dodge_macros.erl",
+                  "src/macros_in_specs.erl",
+                  "src/receive_after.erl"]};
+            {25, _} ->
                 {ignore,
                  ["src/*_ignore.erl",
                   "src/comments.erl",

--- a/test/otp_formatter_SUITE.erl
+++ b/test/otp_formatter_SUITE.erl
@@ -33,7 +33,8 @@ test_app(_Config) ->
                   "src/ignored_file_config.erl",
                   "src/dodge_macros.erl",
                   "src/macros_in_specs.erl",
-                  "src/receive_after.erl"]};
+                  "src/receive_after.erl",
+                  "src/otp26.erl"]};
             _ ->
                 {ignore,
                  ["src/*_ignore.erl",
@@ -42,6 +43,7 @@ test_app(_Config) ->
                   "src/dodge_macros.erl",
                   "src/macros_in_specs.erl",
                   "src/receive_after.erl",
+                  "src/otp26.erl",
                   "src/otp25.erl"]}
         end,
     State2 = rebar_state:set(State1, format, [Files, Formatter, IgnoredFiles]),

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -50,7 +50,10 @@ init_test_app() ->
         case string:to_integer(
                  erlang:system_info(otp_release))
         of
-            {N, []} when N >= 25 ->
+            {N, _} when N >= 26 ->
+                %% newlines in strings are treated differently since OTP26
+                {ignore, ["src/strings/non_heredoc.erl", "src/*_ignore.erl", "src/ignored_file_config.erl"]};
+            {25, _} ->
                 {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
             _ ->
                 {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp25.erl"]}

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -52,11 +52,18 @@ init_test_app() ->
         of
             {N, _} when N >= 26 ->
                 %% newlines in strings are treated differently since OTP26
-                {ignore, ["src/strings/non_heredoc.erl", "src/*_ignore.erl", "src/ignored_file_config.erl"]};
+                {ignore,
+                 ["src/strings/non_heredoc.erl",
+                  "src/*_ignore.erl",
+                  "src/ignored_file_config.erl"]};
             {25, _} ->
-                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]};
+                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp26.erl"]};
             _ ->
-                {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl", "src/otp25.erl"]}
+                {ignore,
+                 ["src/*_ignore.erl",
+                  "src/ignored_file_config.erl",
+                  "src/otp26.erl",
+                  "src/otp25.erl"]}
         end,
     rebar_state:set(State1, format, [Files, IgnoredFiles]).
 

--- a/test_app/after/src/brackets.erl
+++ b/test_app/after/src/brackets.erl
@@ -1,6 +1,7 @@
 -module(brackets).
 
--format #{inline_items => all, paper => 50}.
+-format #{inline_items => all}.
+-format #{paper => 50}.
 
 -compile(export_all).
 

--- a/test_app/after/src/brackets.erl
+++ b/test_app/after/src/brackets.erl
@@ -1,6 +1,6 @@
 -module(brackets).
 
--format #{paper => 50, inline_items => all}.
+-format #{inline_items => all, paper => 50}.
 
 -compile(export_all).
 

--- a/test_app/after/src/brackets.erl
+++ b/test_app/after/src/brackets.erl
@@ -1,6 +1,6 @@
 -module(brackets).
 
--format #{inline_items => all, paper => 50}.
+-format #{paper => 50, inline_items => all}.
 
 -compile(export_all).
 

--- a/test_app/after/src/brackets_ignore.erl
+++ b/test_app/after/src/brackets_ignore.erl
@@ -1,7 +1,8 @@
 %% This module should not be formatted since it's in the list of ignored modules
 -module(brackets_ignore).
 
--format(#{paper => 50, inline_items => all}).
+-format(#{paper => 50}).
+-format(#{inline_items => all}).
 
 -compile(export_all).
 

--- a/test_app/after/src/inline_items/inline_items_when_over.erl
+++ b/test_app/after/src/inline_items/inline_items_when_over.erl
@@ -3,7 +3,7 @@
 %%      per line if they're larger than 5 elements.
 -module(inline_items_when_over).
 
--format #{inline_items => {when_over, 5}, paper => 80}.
+-format #{paper => 80, inline_items => {when_over, 5}}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_items_when_over.erl
+++ b/test_app/after/src/inline_items/inline_items_when_over.erl
@@ -3,7 +3,8 @@
 %%      per line if they're larger than 5 elements.
 -module(inline_items_when_over).
 
--format #{inline_items => {when_over, 5}, paper => 80}.
+-format #{paper => 80}.
+-format #{inline_items => {when_over, 5}}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_items_when_over.erl
+++ b/test_app/after/src/inline_items/inline_items_when_over.erl
@@ -3,7 +3,7 @@
 %%      per line if they're larger than 5 elements.
 -module(inline_items_when_over).
 
--format #{paper => 80, inline_items => {when_over, 5}}.
+-format #{inline_items => {when_over, 5}, paper => 80}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_items_when_under.erl
+++ b/test_app/after/src/inline_items/inline_items_when_under.erl
@@ -1,6 +1,7 @@
 -module(inline_items_when_under).
 
--format #{inline_items => {when_under, 5}, paper => 80}.
+-format #{paper => 80}.
+-format #{inline_items => {when_under, 5}}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_items_when_under.erl
+++ b/test_app/after/src/inline_items/inline_items_when_under.erl
@@ -1,6 +1,6 @@
 -module(inline_items_when_under).
 
--format #{paper => 80, inline_items => {when_under, 5}}.
+-format #{inline_items => {when_under, 5}, paper => 80}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_items_when_under.erl
+++ b/test_app/after/src/inline_items/inline_items_when_under.erl
@@ -1,6 +1,6 @@
 -module(inline_items_when_under).
 
--format #{inline_items => {when_under, 5}, paper => 80}.
+-format #{paper => 80, inline_items => {when_under, 5}}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_no_items.erl
+++ b/test_app/after/src/inline_items/inline_no_items.erl
@@ -3,7 +3,8 @@
 %%      per line if they're large.
 -module(inline_no_items).
 
--format #{inline_items => none, paper => 80}.
+-format #{inline_items => none}.
+-format #{paper => 80}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_no_items.erl
+++ b/test_app/after/src/inline_items/inline_no_items.erl
@@ -3,7 +3,7 @@
 %%      per line if they're large.
 -module(inline_no_items).
 
--format #{paper => 80, inline_items => none}.
+-format #{inline_items => none, paper => 80}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_items/inline_no_items.erl
+++ b/test_app/after/src/inline_items/inline_no_items.erl
@@ -3,7 +3,7 @@
 %%      per line if they're large.
 -module(inline_no_items).
 
--format #{inline_items => none, paper => 80}.
+-format #{paper => 80, inline_items => none}.
 
 -export([short_tuple/0, short_list/0, short_fun/0]).
 -export([short_bin/0, short_guard/1, short_lc/0]).

--- a/test_app/after/src/inline_qualified_function_composition/function_composition_spaces.erl
+++ b/test_app/after/src/inline_qualified_function_composition/function_composition_spaces.erl
@@ -1,6 +1,7 @@
 -module(function_composition_spaces).
 
--format #{inline_qualified_function_composition => true, spaces_around_arguments => true}.
+-format #{inline_qualified_function_composition => true}.
+-format #{spaces_around_arguments => true}.
 
 -export([local_calls/3, external_calls/0]).
 

--- a/test_app/after/src/matches.erl
+++ b/test_app/after/src/matches.erl
@@ -1,6 +1,7 @@
 -compile(export_all).
 
--format #{paper => 80, ribbon => 75}.
+-format #{paper => 80}.
+-format #{ribbon => 75}.
 
 matches() ->
     % Short

--- a/test_app/after/src/otp26.erl
+++ b/test_app/after/src/otp26.erl
@@ -1,0 +1,24 @@
+%% @doc New stuff introduced in OTP26.
+-module(otp26).
+
+-export([map_comprehensions/3]).
+
+map_comprehensions(Map, List, Binary) ->
+    MapFromList = #{{k, Key} => {value, Value} || Key <- List, Value <- List},
+    MapFromBinary =
+        #{{k, Key} => {value, Value}
+          || <<Key/float>> <- Binary, Key >= 8.24551123345, <<Value/binary>> <- Binary},
+    MapFromMap =
+        #{#{key => Key} => [value, Value, is_a_value]
+          || {k, Key} := {value, Value} <- MapFromList, is_integer(Key)},
+    MapFromCombo = #{Key => binary_to_atom(Value) || Key <- List, <<Value/binary>> <= Binary},
+    ListFromMap =
+        [{Key, Value}
+         || {k, Key} := Value <- MapFromBinary,
+            with:one_filter(Key),
+            with:another_filter(Value) == <<"a good value">>],
+    BinaryFromMap =
+        << <<Key:64, $|, Value/binary>>
+           || #{key := Key} := [value, Value | _] <- MapFromMap, is_binary(Value) >>,
+    NoGenerator = #{k => v || this:is_true()},
+    #{MapFromCombo => ListFromMap, BinaryFromMap => NoGenerator}.

--- a/test_app/after/src/paper_and_ribbon/indent_18.erl
+++ b/test_app/after/src/paper_and_ribbon/indent_18.erl
@@ -1,9 +1,9 @@
 -module(indent_18).
 
--format #{break_indent => 1,
-          inline_clause_bodies => true,
+-format #{sub_indent => 8,
+          break_indent => 1,
           paper => 50,
-          sub_indent => 8}.
+          inline_clause_bodies => true}.
 
 -record(record,
         {fields =

--- a/test_app/after/src/paper_and_ribbon/indent_18.erl
+++ b/test_app/after/src/paper_and_ribbon/indent_18.erl
@@ -1,9 +1,9 @@
 -module(indent_18).
 
--format #{sub_indent => 8,
-          break_indent => 1,
+-format #{break_indent => 1,
+          inline_clause_bodies => true,
           paper => 50,
-          inline_clause_bodies => true}.
+          sub_indent => 8}.
 
 -record(record,
         {fields =

--- a/test_app/after/src/paper_and_ribbon/indent_18.erl
+++ b/test_app/after/src/paper_and_ribbon/indent_18.erl
@@ -1,9 +1,9 @@
 -module(indent_18).
 
--format #{break_indent => 1,
-          inline_clause_bodies => true,
-          paper => 50,
-          sub_indent => 8}.
+-format #{break_indent => 1}.
+-format #{inline_clause_bodies => true}.
+-format #{paper => 50}.
+-format #{sub_indent => 8}.
 
 -record(record,
         {fields =

--- a/test_app/after/src/paper_and_ribbon/indent_81.erl
+++ b/test_app/after/src/paper_and_ribbon/indent_81.erl
@@ -1,8 +1,8 @@
 -module(indent_81).
 
--format #{sub_indent => 1,
-          break_indent => 8,
-          paper => 50}.
+-format #{break_indent => 8,
+          paper => 50,
+          sub_indent => 1}.
 -format #{inline_clause_bodies => true}.
 
 -record(record,

--- a/test_app/after/src/paper_and_ribbon/indent_81.erl
+++ b/test_app/after/src/paper_and_ribbon/indent_81.erl
@@ -1,8 +1,8 @@
 -module(indent_81).
 
--format #{break_indent => 8,
-          paper => 50,
-          sub_indent => 1}.
+-format #{break_indent => 8}.
+-format #{paper => 50}.
+-format #{sub_indent => 1}.
 -format #{inline_clause_bodies => true}.
 
 -record(record,

--- a/test_app/after/src/paper_and_ribbon/indent_81.erl
+++ b/test_app/after/src/paper_and_ribbon/indent_81.erl
@@ -1,8 +1,8 @@
 -module(indent_81).
 
--format #{break_indent => 8,
-          paper => 50,
-          sub_indent => 1}.
+-format #{sub_indent => 1,
+          break_indent => 8,
+          paper => 50}.
 -format #{inline_clause_bodies => true}.
 
 -record(record,

--- a/test_app/after/src/strings/non_heredoc.erl
+++ b/test_app/after/src/strings/non_heredoc.erl
@@ -1,0 +1,15 @@
+-module(strings).
+
+-export([heredoc/0]).
+
+-format #{inline_expressions => true}.
+
+heredoc() ->
+    {ok,
+     "" "
+This is
+a multiline
+heredoc but there are
+no multiline heredocs in Erlang :'(
+"
+     ""}.

--- a/test_app/after/src/strings/strings.erl
+++ b/test_app/after/src/strings/strings.erl
@@ -7,21 +7,11 @@
 -attr({with, "a string"}).
 
 all() ->
-    heredoc(), superlong(), repeat(), multiple_calls(), characters(), multiline_with_spaces().
+    superlong(), repeat(), multiple_calls(), characters(), multiline_with_spaces().
 
 superlong() ->
     "This is a super super super super super super super super super super super super super super super super super super super super super super super super super super super super super long string!"
     "Shouldn't be truncated since truncate_strings => false by default".
-
-heredoc() ->
-    {ok,
-     "" "
-This is
-a multiline
-heredoc but there are
-no multiline heredocs in Erlang :'(
-"
-     ""}.
 
 repeat() ->
     ["hello", "there", "hello", "there", "hello", "there" | repeat_more()].

--- a/test_app/src/brackets.erl
+++ b/test_app/src/brackets.erl
@@ -1,6 +1,7 @@
 -module(brackets).
 
--format(#{inline_items => all, paper => 50}).
+-format(#{inline_items => all}).
+-format(#{paper => 50}).
 
 -compile(export_all).
 

--- a/test_app/src/brackets.erl
+++ b/test_app/src/brackets.erl
@@ -1,6 +1,6 @@
 -module(brackets).
 
--format(#{paper => 50, inline_items => all}).
+-format(#{inline_items => all, paper => 50}).
 
 -compile(export_all).
 

--- a/test_app/src/brackets_ignore.erl
+++ b/test_app/src/brackets_ignore.erl
@@ -1,7 +1,8 @@
 %% This module should not be formatted since it's in the list of ignored modules
 -module(brackets_ignore).
 
--format(#{paper => 50, inline_items => all}).
+-format(#{paper => 50}).
+-format(#{inline_items => all}).
 
 -compile(export_all).
 

--- a/test_app/src/inline_items/inline_items_when_over.erl
+++ b/test_app/src/inline_items/inline_items_when_over.erl
@@ -3,7 +3,8 @@
 %%      per line if they're larger than 5 elements.
 -module inline_items_when_over.
 
--format #{paper => 80, inline_items => {when_over, 5}}.
+-format #{paper => 80}.
+-format #{inline_items => {when_over, 5}}.
 
 -export [short_tuple/0, short_list/0, short_fun/0].
 -export [short_bin/0, short_guard/1, short_lc/0].
@@ -106,4 +107,3 @@ exact() ->
 
 long() ->
     [these, items, should, be, inlined, they, are, more, than, 25, $., 'We', can, be, sure, about, that, because, we, added, a, very, long, number, 'of', items, to, this, list].
-

--- a/test_app/src/inline_items/inline_items_when_under.erl
+++ b/test_app/src/inline_items/inline_items_when_under.erl
@@ -1,6 +1,7 @@
 -module inline_items_when_under.
 
--format #{paper => 80, inline_items => {when_under, 5}}.
+-format #{paper => 80}.
+-format #{inline_items => {when_under, 5}}.
 
 -export [short_tuple/0, short_list/0, short_fun/0].
 -export [short_bin/0, short_guard/1, short_lc/0].
@@ -103,4 +104,3 @@ exact() ->
 
 long() ->
     [these, items, should, be, inlined, they, are, more, than, 25, $., 'We', can, be, sure, about, that, because, we, added, a, very, long, number, 'of', items, to, this, list].
-

--- a/test_app/src/inline_items/inline_no_items.erl
+++ b/test_app/src/inline_items/inline_no_items.erl
@@ -3,7 +3,7 @@
 %%      per line if they're large.
 -module inline_no_items.
 
--format #{paper => 80, inline_items => none}.
+-format #{inline_items => none, paper => 80}.
 
 -export [short_tuple/0, short_list/0, short_fun/0].
 -export [short_bin/0, short_guard/1, short_lc/0].
@@ -106,4 +106,3 @@ exact() ->
 
 long() ->
     [these, items, should, be, inlined, they, are, more, than, 25, $., 'We', can, be, sure, about, that, because, we, added, a, very, long, number, 'of', items, to, this, list].
-

--- a/test_app/src/inline_items/inline_no_items.erl
+++ b/test_app/src/inline_items/inline_no_items.erl
@@ -3,7 +3,8 @@
 %%      per line if they're large.
 -module inline_no_items.
 
--format #{inline_items => none, paper => 80}.
+-format #{inline_items => none}.
+-format #{paper => 80}.
 
 -export [short_tuple/0, short_list/0, short_fun/0].
 -export [short_bin/0, short_guard/1, short_lc/0].

--- a/test_app/src/inline_qualified_function_composition/function_composition_spaces.erl
+++ b/test_app/src/inline_qualified_function_composition/function_composition_spaces.erl
@@ -1,6 +1,7 @@
 -module(function_composition_spaces).
 
--format #{spaces_around_arguments => true, inline_qualified_function_composition => true}.
+-format #{inline_qualified_function_composition => true}.
+-format #{spaces_around_arguments => true}.
 
 -export([local_calls/3, external_calls/0]).
 

--- a/test_app/src/matches.erl
+++ b/test_app/src/matches.erl
@@ -1,6 +1,7 @@
 -compile(export_all).
 
--format #{paper => 80, ribbon => 75}.
+-format #{paper => 80}.
+-format #{ribbon => 75}.
 
 matches() ->
     % Short

--- a/test_app/src/otp26.erl
+++ b/test_app/src/otp26.erl
@@ -1,0 +1,14 @@
+%% @doc New stuff introduced in OTP26.
+-module(otp26).
+
+-export([map_comprehensions/3]).
+
+map_comprehensions(Map, List, Binary) ->
+    MapFromList = #{ {k, Key} => {value, Value} || Key <- List, Value <- List },
+    MapFromBinary = #{ {k, Key} => {value, Value} || <<Key/float>> <- Binary, Key >= 8.24551123345, <<Value/binary>> <- Binary},
+    MapFromMap = #{ #{key => Key} => [value, Value, is_a_value] || {k, Key} := {value, Value} <- MapFromList, is_integer(Key) },
+    MapFromCombo = #{ Key => binary_to_atom(Value) || Key <- List, <<Value/binary>> <= Binary},
+    ListFromMap = [{Key, Value} || {k, Key} := Value <- MapFromBinary, with:one_filter(Key), with:another_filter(Value) == <<"a good value">>],
+    BinaryFromMap = << <<Key:64, $|, Value/binary>> || #{key := Key} := [value, Value | _] <- MapFromMap, is_binary(Value) >>,
+    NoGenerator = #{k => v || this:is_true()},
+    #{MapFromCombo => ListFromMap, BinaryFromMap => NoGenerator}.

--- a/test_app/src/otp26.erl
+++ b/test_app/src/otp26.erl
@@ -4,11 +4,21 @@
 -export([map_comprehensions/3]).
 
 map_comprehensions(Map, List, Binary) ->
-    MapFromList = #{ {k, Key} => {value, Value} || Key <- List, Value <- List },
-    MapFromBinary = #{ {k, Key} => {value, Value} || <<Key/float>> <- Binary, Key >= 8.24551123345, <<Value/binary>> <- Binary},
-    MapFromMap = #{ #{key => Key} => [value, Value, is_a_value] || {k, Key} := {value, Value} <- MapFromList, is_integer(Key) },
-    MapFromCombo = #{ Key => binary_to_atom(Value) || Key <- List, <<Value/binary>> <= Binary},
-    ListFromMap = [{Key, Value} || {k, Key} := Value <- MapFromBinary, with:one_filter(Key), with:another_filter(Value) == <<"a good value">>],
-    BinaryFromMap = << <<Key:64, $|, Value/binary>> || #{key := Key} := [value, Value | _] <- MapFromMap, is_binary(Value) >>,
+    MapFromList = #{{k, Key} => {value, Value} || Key <- List, Value <- List},
+    MapFromBinary =
+        #{{k, Key} => {value, Value}
+          || <<Key/float>> <- Binary, Key >= 8.24551123345, <<Value/binary>> <- Binary},
+    MapFromMap =
+        #{#{key => Key} => [value, Value, is_a_value]
+          || {k, Key} := {value, Value} <- MapFromList, is_integer(Key)},
+    MapFromCombo = #{Key => binary_to_atom(Value) || Key <- List, <<Value/binary>> <= Binary},
+    ListFromMap =
+        [{Key, Value}
+         || {k, Key} := Value <- MapFromBinary,
+            with:one_filter(Key),
+            with:another_filter(Value) == <<"a good value">>],
+    BinaryFromMap =
+        << <<Key:64, $|, Value/binary>>
+           || #{key := Key} := [value, Value | _] <- MapFromMap, is_binary(Value) >>,
     NoGenerator = #{k => v || this:is_true()},
     #{MapFromCombo => ListFromMap, BinaryFromMap => NoGenerator}.

--- a/test_app/src/paper_and_ribbon/indent_18.erl
+++ b/test_app/src/paper_and_ribbon/indent_18.erl
@@ -1,9 +1,9 @@
 -module(indent_18).
 
 -format(#{break_indent => 1,
-          sub_indent => 8,
+          inline_clause_bodies => true,
           paper => 50,
-          inline_clause_bodies => true}).
+          sub_indent => 8}).
 
 -record(
     record, {fields = should:be(indented_using:break_indent(1)),

--- a/test_app/src/paper_and_ribbon/indent_18.erl
+++ b/test_app/src/paper_and_ribbon/indent_18.erl
@@ -1,9 +1,9 @@
 -module(indent_18).
 
--format(#{break_indent => 1,
-          inline_clause_bodies => true,
-          paper => 50,
-          sub_indent => 8}).
+-format(#{break_indent => 1}).
+-format(#{inline_clause_bodies => true}).
+-format(#{paper => 50}).
+-format(#{sub_indent => 8}).
 
 -record(
     record, {fields = should:be(indented_using:break_indent(1)),

--- a/test_app/src/paper_and_ribbon/indent_81.erl
+++ b/test_app/src/paper_and_ribbon/indent_81.erl
@@ -1,6 +1,6 @@
 -module(indent_81).
 
--format(#{break_indent => 8, sub_indent => 1, paper => 50}).
+-format(#{break_indent => 8, paper => 50, sub_indent => 1}).
 -format(#{inline_clause_bodies => true}).
 
 -record(

--- a/test_app/src/paper_and_ribbon/indent_81.erl
+++ b/test_app/src/paper_and_ribbon/indent_81.erl
@@ -1,6 +1,8 @@
 -module(indent_81).
 
--format(#{break_indent => 8, paper => 50, sub_indent => 1}).
+-format(#{break_indent => 8}).
+-format(#{paper => 50}).
+-format(#{sub_indent => 1}).
 -format(#{inline_clause_bodies => true}).
 
 -record(

--- a/test_app/src/strings/non_heredoc.erl
+++ b/test_app/src/strings/non_heredoc.erl
@@ -1,0 +1,15 @@
+-module(strings).
+
+-export([heredoc/0]).
+
+-format #{inline_expressions => true}.
+
+heredoc() ->
+    {ok,
+     "" "
+This is
+a multiline
+heredoc but there are
+no multiline heredocs in Erlang :'(
+"
+     ""}.

--- a/test_app/src/strings/strings.erl
+++ b/test_app/src/strings/strings.erl
@@ -7,7 +7,6 @@
 -attr({with, "a string"}).
 
 all() ->
-  heredoc(),
   superlong(),
   repeat(),
   multiple_calls(),
@@ -18,14 +17,6 @@ all() ->
 superlong() ->
   "This is a super super super super super super super super super super super super super super super super super super super super super super super super super super super super super long string!"
   "Shouldn't be truncated since truncate_strings => false by default".
-
-heredoc() ->
-{ok, """
-This is
-a multiline
-heredoc but there are
-no multiline heredocs in Erlang :'(
-"""}.
 
 repeat() ->
   ["hello", "there",


### PR DESCRIPTION
The original intention of this PR was upgrading **only** the `otp_formatter` to work with OTP 26 and 27 so a future PR could update the other formatters. But I quickly realized that, in order to run tests with newer versions of OTP, I needed to update *all* the formatters.
So… missing tasks:

- [x] Upgrade dependencies
- [x] Update other formatters
- [x] Get tests to pass on both OTP 25 and OTP 26
- [X] Remove OTP 24 from github's workflows and set min-version to 25
- [x] Add tests for OTP26 syntax:
    - [x] map comprehensions
    - [x] Compare OTP's `lib/syntax_tools/test/syntax_tools_SUITE_data/` between versions.