### PR TITLE
[RTI-16019] Will it work with OTP 27? It shouldn't! But let's find out

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -9,11 +9,11 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
-        otp: ['25', '26']
+        otp: ['25', '26', '27']
         rebar: ['3.24']
 
     steps:


### PR DESCRIPTION
It seems to work but this doesn't mean it's OTP 27 compatible the reason is because it doesn't support new OTP 27 features, I would say it's semi-compatible as long as you don't use OTP 27 new features.

See https://github.com/AdRoll/rebar3_format/issues/359 for more details.